### PR TITLE
feat: add workflow that automatically pulls upstream

### DIFF
--- a/.github/workflows/pull-upstream.yml
+++ b/.github/workflows/pull-upstream.yml
@@ -1,0 +1,91 @@
+on:
+  schedule:
+    - cron: "10 10 * * *" # This gives mirror sync, which runs at 9:57, some time to complete.
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  upstream: "https://github.com/mage-os/mirror-magento2.git"
+
+jobs:
+  pull-upstream:
+    name: "Pull Upstream"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # We might support other branches in the future.
+        branch: [ '2.4-develop' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+
+      # If there is already a 2.x-develop-upstream branch, we're in the process of handling a conflict.
+      # Skip any subsequent steps.
+      - name: Check if we're already resolving conflicts
+        run: "! git ls-remote --exit-code origin ${{ matrix.branch }}-upstream"
+
+      # Add the upstream remote, in normal circumstances this will be mirror-magento2.
+      - name: Set upstream
+        run: git remote add upstream ${{ env.upstream }}
+
+      # These settings are required for the merge commit.
+      - name: Configure git
+        run: |
+          git config user.email info@mage-os.org
+          git config user.name "Mage-OS"
+
+      # Instead of doing a git pull, we do a fetch followed by a merge.
+      # This is functionally equivalent, but allows us to capture the output of the merge specifically.
+      - name: Attempt merge
+        id: merge
+        run: |
+          git fetch upstream ${{ matrix.branch }}
+          git merge --no-edit FETCH_HEAD 2>&1 | tee merge.log
+          result_code=${PIPESTATUS[0]}
+          echo "::set-output name=merge::$(cat merge.log)"
+          exit $result_code
+
+      # When merge succeeds, simply push to the original branch.
+      # If an upstream branch exists, we'll delete it.
+      - name: Push
+        run: |
+          git push origin ${{ matrix.branch }}
+          git push --delete origin ${{ matrix.branch }}-upstream || true
+
+      # If the merge failed, checkout the upstream branch and push it to our repo.
+      - name: Create Upstream Branch
+        id: create_branch
+        if: failure() && steps.merge.outcome == 'failure'
+        run: |
+          git merge --abort
+          git checkout -b ${{ matrix.branch }}-upstream FETCH_HEAD
+          git push --set-upstream --force origin ${{ matrix.branch }}-upstream
+          git remote remove upstream
+
+      # If the merge failed, and we successfully created an upstream branch, create a pull request.
+      - name: Create Pull Request
+        id: create_pr
+        if: failure() && steps.merge.outcome == 'failure' && steps.create_branch.outcome == 'success'
+        uses: devops-infra/action-pull-request@v0.5.0
+        with:
+          draft: true
+          title: "Upstream Merge Conflict (${{ matrix.branch }})"
+          body: "This PR was automatically generated: a human is required.\n\n${{ steps.merge.outputs.merge }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: ${{ matrix.branch }}-upstream
+          target_branch: ${{ matrix.branch }}
+
+      # If the merge failed, and we successfully created a PR, send a message to discord.
+      - name: Notify Discord
+        if: failure() && steps.merge.outcome == 'failure' && steps.create_pr.outcome == 'success'
+        uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: "Mage-OS"
+          DISCORD_EMBEDS: '[{"title": "Upstream Merge Conflict", "description": "Pull Request: ${{ steps.create_pr.outputs.url }}\nAction: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n\nConflicts:\n ${{ steps.merge.outputs.merge }}"}]'


### PR DESCRIPTION
### Description (*)

This pull request adds a workflow that automatically attempts to pull from upstream. It is done every morning at 10:10am. This gives the mirror sync some time to complete.

When the merge succeeds, we simply allow it to happen and push it to our repository.

When the merge fails, we create a `2.x-develop-upstream` branch. This branch is then used to create a (draft) Pull Request that can be manually handled by a human.

As long as this `2.x-develop-upstream` branch exists (in other words: as long as there hasn't been a conflict resolution), we will not attempt an automatic merge again. This does mean that we need to ensure to also manually delete the upstream branch whenever we have solved the conflict. I intend to create a separate github action in a separate PR to handle this automatically.

Finally, after the Pull Request has been created, we send a notification to the Mage-OS discord with a link to the PR and the output of the (failed) merge.

Please note that this workflow requires a secret called `DISCORD_WEBHOOK`. It must be configured in the repository settings.

If you have any comments or questions, I'm happy to hear them!