### PR TITLE
ci: run magento coding standard for pull requests

### DIFF
--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -1,0 +1,16 @@
+name: Coding Standard
+
+on:
+  pull_request:
+    branches:
+      - 2.4-develop
+
+permissions:
+  contents: read
+
+jobs:
+  coding-standard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Coding Standard
+        uses: graycoreio/github-actions-magento2/coding-standard@main


### PR DESCRIPTION
### Description

Runs the Magento Coding Standard on Pull Requests. 
The check will only be performed for files that were added/modified within the pull request.

After installing dependencies from the lock file, we update the coding standard to the latest version. 
The lock file might have an older version, in my case it was locked to v23, but we're already at v25 (which made me run into [this](https://github.com/magento/magento-coding-standard/issues/86) issue.

Some questions:
- Would it be worth to use a filter pattern for the branch name. Should we use something like `'2.[0-9]-develop'`?
- This currently only runs for `pull_request`, not for `push`. Is there a scenario where we would need to run on `push` as well? We should assume that direct pushes to the main branch is prohibited to any contributor: any code that we do introduce is done by PRs, which we are checking here. Supporting `push` might be trickier, as we currently rely on `github.event.pull_request.base.sha`.
- Should we be using this specific standard at all? Are there better things out there? Should we stick with consistency?

Would love to hear your thoughts!