### PR TITLE
Increase the default max admin session size to 1 MB

### DIFF
--- a/app/code/Magento/Security/etc/config.xml
+++ b/app/code/Magento/Security/etc/config.xml
@@ -18,7 +18,7 @@
         </admin>
         <system>
             <security>
-                <max_session_size_admin>256000</max_session_size_admin>
+                <max_session_size_admin>1024000</max_session_size_admin>
                 <max_session_size_storefront>256000</max_session_size_storefront>
             </security>
         </system>


### PR DESCRIPTION
### Description (*)
In Magento 2.4.3, a security feature was added to restrict the total size of admin and frontend sessions. Both were capped at 256 KB (256000 bytes) by default, adjustable by configuration. Upon hitting the session limit, a session gets terminated (admin gets redirected to the login page), without error.

Unfortunately, the 256 KB limit is too low for admin sessions, and can be routinely hit by normal admin usage on a standard install. This results in inexplicable session terminations and forced reauthentication, often on save actions, causing unnecessary user grief.

This PR raises the adminhtml session max size default from 256 KB to 1024 KB. It is my belief that this will be sufficient to avoid unnecessary session termination, while still protecting issues from overly large sessions. The system should not break without warning in its default and expected configuration.

Fundamentally, the issue would be better addressed by reducing the amount of data stored in admin sessions rather than blindly terminating large ones, but this is an easy solution meanwhile.

Some related discussions:
https://github.com/magento/magento2/issues/33748
https://github.com/magento/magento2/issues/34064

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
