### PR TITLE
Disable Admin Usage Data Collection by Default

### DIFF
--- a/app/code/Magento/AdminAnalytics/etc/config.xml
+++ b/app/code/Magento/AdminAnalytics/etc/config.xml
@@ -10,7 +10,7 @@
         <admin>
             <usage>
                 <enabled>
-                    1
+                    0
                 </enabled>
             </usage>
         </admin>

--- a/app/code/Magento/AdminAnalytics/view/adminhtml/layout/adminhtml_dashboard_index.xml
+++ b/app/code/Magento/AdminAnalytics/view/adminhtml/layout/adminhtml_dashboard_index.xml
@@ -12,7 +12,10 @@
             <uiComponent name="admin_usage_notification">
                 <visibilityCondition name="can_view_admin_usage_notification" className="Magento\AdminAnalytics\Model\Condition\CanViewNotification"/>
             </uiComponent>
-            <block name="tracking_notification" as="tracking_notification" template="Magento_AdminAnalytics::notification.phtml">
+            <block name="tracking_notification"
+                   as="tracking_notification"
+                   template="Magento_AdminAnalytics::notification.phtml"
+                   ifconfig="admin/usage/enabled">
                 <arguments>
                     <argument name="notification" xsi:type="object">Magento\AdminAnalytics\ViewModel\Notification</argument>
                 </arguments>


### PR DESCRIPTION
### Description (*)
Updates default behaviour to disable the data collection implemented by `Magento_AdminAnalytics`.

### Fixed Issues
Fixes mage-os/mageos-magento2#43

### Manual testing scenarios (*)
1. Install the 1.0.0 preview and log into the backend as an admin user.
2. Observe the related configuration option is disabled upon installation
    - `Stores -> Settings -> Configuration -> Advanced -> Admin -> Admin Usage`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
