### PR TITLE
Update GitHub Templates

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Magento Code of Conduct
+# Mage-OS Code of Conduct
 
 ## Our Pledge
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Contributing to Magento 2 code
 
-Contributions to the Magento 2 codebase are done using the fork & pull model.
-This contribution model has contributors maintaining their own fork of the Magento 2 repository.
+Contributions to the Mage-OS Magento 2 codebase are done using the fork & pull model.
+This contribution model has contributors maintaining their own fork of the Mage-OS Magento 2 repository.
 The forked repository is then used to submit a request to the base repository to “pull” a set of changes.
 For more information on pull requests please refer to [GitHub Help](https://help.github.com/articles/about-pull-requests/).
 
 Contributions can take the form of new components or features, changes to existing features, tests, documentation (such as developer guides, user guides, examples, or specifications), bug fixes or optimizations.
 
-The Magento 2 development team or community maintainers will review all issues and contributions submitted by the community of developers in the first in, first out order.
+The Mage-OS Magento 2 development team or community maintainers will review all issues and contributions submitted by the community of developers in the first in, first out order.
 During the review we might require clarifications from the contributor.
 If there is no response from the contributor within two weeks, the pull request will be closed.
 
@@ -17,24 +17,24 @@ For more detailed information on contribution please read our [beginners guide](
 
 1. Contributions must adhere to the [Magento coding standards](https://developer.adobe.com/commerce/php/coding-standards/).
 2. Pull requests (PRs) must be accompanied by a meaningful description of their purpose. Comprehensive descriptions increase the chances of a pull request being merged quickly and without additional clarification requests.
-3. Commits must be accompanied by meaningful commit messages. Please see the [Magento Pull Request Template](https://github.com/magento/magento2/blob/HEAD/.github/PULL_REQUEST_TEMPLATE.md) for more information.
+3. Commits must be accompanied by meaningful commit messages. Please see the [Mage-OS Magento Pull Request Template](https://github.com/mage-os/mageos-magento2/blob/HEAD/.github/PULL_REQUEST_TEMPLATE.md) for more information.
 4. PRs which include bug fixes must be accompanied with a step-by-step description of how to reproduce the bug.
 3. PRs which include new logic or new features must be submitted along with:
 * Unit/integration test coverage
 * Proposed [documentation](https://devdocs.magento.com) updates. Documentation contributions can be submitted via the [devdocs GitHub](https://github.com/magento/devdocs).
-4. For larger features or changes, please [open an issue](https://github.com/magento/magento2/issues) to discuss the proposed changes prior to development. This may prevent duplicate or unnecessary effort and allow other contributors to provide input.
+4. For larger features or changes, please [open an issue](https://github.com/mage-os/mageos-magento2/issues) to discuss the proposed changes prior to development. This may prevent duplicate or unnecessary effort and allow other contributors to provide input.
 5. All automated tests must pass.
 
 ## Contribution process
 
 If you are a new GitHub user, we recommend that you create your own [free github account](https://github.com/signup/free).
-This will allow you to collaborate with the Magento 2 development team, fork the Magento 2 project and send pull requests.
+This will allow you to collaborate with the Mage-OS Magento 2 development team, fork the Mage-OS Magento 2 project and send pull requests.
 
-1. Search current [listed issues](https://github.com/magento/magento2/issues) (open or closed) for similar proposals of intended contribution before starting work on a new contribution.
+1. Search current [listed issues](https://github.com/mage-os/mageos-magento2/issues) (open or closed) for similar proposals of intended contribution before starting work on a new contribution.
 2. Review the [Contributor License Agreement](https://opensource.adobe.com/cla.html) if this is your first time contributing.
 3. Create and test your work.
-4. Follow the [Forks And Pull Requests Instructions](https://developer.adobe.com/commerce/contributor/guides/code-contributions/) to fork the Magento 2 repository and send us a pull request.
-5. Once your contribution is received the Magento 2 development team will review the contribution and collaborate with you as needed.
+4. Follow the [Forks And Pull Requests Instructions](https://developer.adobe.com/commerce/contributor/guides/code-contributions/) to fork the Mage-OS Magento 2 repository and send us a pull request.
+5. Once your contribution is received the Mage-OS Magento 2 development team will review the contribution and collaborate with you as needed.
 
 ## Code of Conduct
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!---
-    Thank you for contributing to Magento.
+    Thank you for contributing to Mage-OS.
     To help us process this issue we recommend that you add the following information:
      - Summary of the issue,
      - Information on your environment,
@@ -13,7 +13,7 @@
 ### Preconditions (*)
 <!---
     Please provide as detailed information about your environment as possible.
-    For example Magento version, tag, HEAD, PHP & MySQL version, etc..
+    For example Mage-OS Magento version, tag, HEAD, PHP & MySQL version, etc..
 -->
 1. 
 2. 

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Technical issue with the Magento 2 core components
+description: Technical issue with the Mage-OS Magento 2 core components
 body:
   - type: markdown
     attributes:
@@ -12,7 +12,7 @@ body:
         Describe your environment.
         Provide all the details that will help us to reproduce the bug.
       value: |
-        - Magento version
+        - Mage-OS Magento version
         - Anything else that would help a developer reproduce the bug
   - type: textarea
     attributes:
@@ -51,7 +51,7 @@ body:
     attributes:
       label: Additional information
       description: |
-        Additional information is often requested when the bug report is processed. You can save time by providing both Magento and browser logs, screenshots, repository branch and HEAD commit you checked out to install Magento and any other artifacts related to the issue.
+        Additional information is often requested when the bug report is processed. You can save time by providing both Mage-OS Magento and browser logs, screenshots, repository branch and HEAD commit you checked out to install Magento and any other artifacts related to the issue.
         Also, links to the comments with important information, Root Cause analysis, additional video recordings; and anything else that is important for the issue and at some reason cannot be added to other sections.
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Important: This repository is intended only for Magento 2 Technical Issues.
+        Important: This repository is intended only for Mage-OS Magento 2 Technical Issues.
         Enter Feature Requests at https://github.com/magento/community-features.
         Project stakeholders monitor and manage requests.
         Feature requests entered using this form may be moved to the forum.
@@ -28,7 +28,7 @@ body:
     attributes:
       label: Benefits
       description: |
-        How do you think this feature would improve Magento?
+        How do you think this feature would improve Mage-OS Magento?
   - type: textarea
     attributes:
       label: Additional information

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!---
-    Thank you for contributing to Magento.
+    Thank you for contributing to Mage-OS.
     To help us process this pull request we recommend that you add the following information:
      - Summary of the pull request,
      - Issue(s) related to the changes made,
@@ -20,10 +20,10 @@
 
 ### Fixed Issues (if relevant)
 <!---
-    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
+    If relevant, please provide a list of fixed issues in the format mage-os/mageos-magento2#<issue_number>.
     There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
 -->
-1. Fixes magento/magento2#<issue_number>
+1. Fixes mage-os/mageos-magento2#<issue_number>
 
 ### Manual testing scenarios (*)
 <!---


### PR DESCRIPTION
### Description (*)
Updates the GitHub templates to reference Mage-OS where sensible. Some links or references are unchanged as the Adobe alternatives are more suitable at present.

### Manual testing scenarios (*)
1. Observe the changes in the GitHub template for sensibility

### Comments
This was a fairly "brute force" method so if it is preferable to leave certain things as they are, I'm happy to undo those changes. I also wasn't sure if there was a preference for `Mage-OS` vs `Mage-OS Magento`. I opted for the latter as I think it's less ambiguous and makes it clear which Mage-OS project we're working with.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
