### PR TITLE
Create category-product index table for store 0

### DIFF
--- a/app/code/Magento/Catalog/Setup/Patch/Schema/EnableSegmentation.php
+++ b/app/code/Magento/Catalog/Setup/Patch/Schema/EnableSegmentation.php
@@ -40,7 +40,7 @@ class EnableSegmentation implements SchemaPatchInterface
         $this->schemaSetup->startSetup();
         $setup = $this->schemaSetup;
 
-        $storeSelect = $setup->getConnection()->select()->from($setup->getTable('store'))->where('store_id > 0');
+        $storeSelect = $setup->getConnection()->select()->from($setup->getTable('store'));
         foreach ($setup->getConnection()->fetchAll($storeSelect) as $store) {
             $indexTable = $setup->getTable('catalog_category_product_index') .
                 '_' .
@@ -54,7 +54,7 @@ class EnableSegmentation implements SchemaPatchInterface
                     )
                 );
             }
-            if (!$setup->getConnection()->isTableExists($indexTable . '_replica')) {
+            if ($store['store_id'] > 0 && !$setup->getConnection()->isTableExists($indexTable . '_replica')) {
                 $setup->getConnection()->createTable(
                     $setup->getConnection()->createTableByDdl(
                         $setup->getTable('catalog_category_product_index'),


### PR DESCRIPTION
### Description (*)
This fixes a regression introduced by pull request https://github.com/mage-os/mageos-magento2/pull/25

### Fixed Issues
1. Fixes mage-os/mageos-magento2#44

### Testing scenarios (*)

Under certain conditions saving or loading a product caused a table-not-exists exception.
This happened for example for the integration test \Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricingTest::testImportDelete

With this change, the index table is created by the schema patch, just like all other store index tables, and the error no longer occurs.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
