### PR TITLE
Use mage-os as vendor-name for composer info

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/composer.json
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "magento/magento2ce",
+    "name": "mage-os/magento2ce",
     "description": "Magento 2 (Community Edition)",
     "type": "project",
     "license": [

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/composer.json
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "magento/project-community-edition",
+    "name": "mage-os/project-community-edition",
     "description": "eCommerce Platform for Growth (Community Edition)",
     "type": "project",
     "license": [

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/composer.lock
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/composer.lock
@@ -9371,7 +9371,7 @@
             "description": "N/A"
         },
         {
-            "name": "magento/product-community-edition",
+            "name": "mage-os/product-community-edition",
             "version": "2.3.1",
             "require": {
                 "amzn/amazon-pay-and-login-magento-2-module": "3.1.4",

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/composer.lock
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/composer.lock
@@ -9371,7 +9371,7 @@
             "description": "N/A"
         },
         {
-            "name": "magento/product-community-edition",
+            "name": "mage-os/product-community-edition",
             "version": "2.3.1",
             "require": {
                 "amzn/amazon-pay-and-login-magento-2-module": "3.1.4",

--- a/lib/internal/Magento/Framework/Composer/ComposerInformation.php
+++ b/lib/internal/Magento/Framework/Composer/ComposerInformation.php
@@ -116,7 +116,7 @@ class ComposerInformation
             foreach ($packages as $package) {
                 if ($package instanceof CompletePackageInterface) {
                     $packageName = $package->getPrettyName();
-                    if ($packageName === 'magento/product-community-edition') {
+                    if ($packageName === 'mage-os/product-community-edition') {
                         $phpRequirementLink = $package->getRequires()['php'];
                         if ($phpRequirementLink instanceof Link) {
                             $requiredPhpVersion = $phpRequirementLink->getPrettyConstraint();
@@ -261,7 +261,7 @@ class ComposerInformation
      */
     public function isSystemPackage($packageName = '')
     {
-        if (preg_match('/magento\/product-.*?-edition/', $packageName) == 1) {
+        if (preg_match('/mage-os\/product-.*?-edition/', $packageName) == 1) {
             return true;
         }
         return false;
@@ -276,7 +276,7 @@ class ComposerInformation
     {
         $rootPackage = $this->getComposer()->getPackage();
 
-        return (boolean)preg_match('/magento\/magento2...?/', $rootPackage->getName());
+        return (boolean)preg_match('/mage-os\/magento2...?/', $rootPackage->getName());
     }
 
     /**

--- a/lib/internal/Magento/Framework/Composer/Test/Unit/ComposerInformationTest.php
+++ b/lib/internal/Magento/Framework/Composer/Test/Unit/ComposerInformationTest.php
@@ -60,8 +60,8 @@ class ComposerInformationTest extends TestCase
         $this->packageMock = $this->getMockForAbstractClass(CompletePackageInterface::class);
         $this->lockerMock->method('getLockedRepository')->willReturn($this->lockerRepositoryMock);
         $this->packageMock->method('getType')->willReturn('metapackage');
-        $this->packageMock->method('getPrettyName')->willReturn('magento/product-test-package-name-edition');
-        $this->packageMock->method('getName')->willReturn('magento/product-test-package-name-edition');
+        $this->packageMock->method('getPrettyName')->willReturn('mage-os/product-test-package-name-edition');
+        $this->packageMock->method('getName')->willReturn('mage-os/product-test-package-name-edition');
         $this->packageMock->method('getPrettyVersion')->willReturn('123.456.789');
         $this->lockerRepositoryMock->method('getPackages')->willReturn([$this->packageMock]);
 
@@ -78,8 +78,8 @@ class ComposerInformationTest extends TestCase
     public function testGetSystemPackages()
     {
         $expected = [
-            'magento/product-test-package-name-edition' => [
-                'name'    => 'magento/product-test-package-name-edition',
+            'mage-os/product-test-package-name-edition' => [
+                'name'    => 'mage-os/product-test-package-name-edition',
                 'type'    => 'metapackage',
                 'version' => '123.456.789'
             ]
@@ -113,8 +113,8 @@ class ComposerInformationTest extends TestCase
     public function isMagentoRootDataProvider()
     {
         return [
-            ['magento/magento2ce', true],
-            ['magento/magento2ee', true],
+            ['mage-os/magento2ce', true],
+            ['mage-os/magento2ee', true],
             ['namespace/package', false],
         ];
     }


### PR DESCRIPTION
### Description (*)

The ComposerInformation class is used to extract information about the current installation from the project root composer.json and composer.lock files, for example the Magento version. To find the relevant information, it looks at the package names, using a vendor name magento.
Without this change, the installed version is reported as "UNKNOWN" in the Magento admin when the mage-os/project-community-edition package is used. This change fixes the regex so it correctly identifies the installed version.

In future, it may be worth generalizing this so it is easier to switch the project vendor for other distributions based on Mage-OS.

### Fixed Issues
Fixes issue #42.

### Manual testing scenarios (*)
1. Install Mage-OS 1.0.0 preview from preview-repo.mage-os.org
2. Log into the admin
3. Check the version information displayed in the footer

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
