### PR TITLE
Remove AdminAnalytics Adobe tracking URL

### DIFF
--- a/app/code/Magento/AdminAnalytics/view/adminhtml/layout/default.xml
+++ b/app/code/Magento/AdminAnalytics/view/adminhtml/layout/default.xml
@@ -10,7 +10,8 @@
         <referenceContainer name="header">
             <block name="tracking" as="tracking" template="Magento_AdminAnalytics::tracking.phtml" ifconfig="admin/usage/enabled">
                 <arguments>
-                    <argument name="tracking_url" xsi:type="string">//assets.adobedtm.com/a7d65461e54e/37baabec1b6e/launch-177bc126c8e6.min.js</argument>
+                    <!-- For Mage-OS the tracking_url is empty by default. -->
+                    <argument name="tracking_url" xsi:type="string"/>
                     <argument name="metadata" xsi:type="object">Magento\AdminAnalytics\ViewModel\Metadata</argument>
                 </arguments>
             </block>


### PR DESCRIPTION
### Description (*)
This change ensures that in case the tracking-feature is enabled in the admin, Mage-OS will not be tracked as Magento Open Source or Enterprise Edition installations incorrectly.

In order to use admin analytics, a custom tracking_url script needs to be configured on the tracking block.


### Related Pull Requests
[Disable Admin Usage Data Collection by Default](https://github.com/mage-os/mageos-magento2/pull/45)


### Fixed Issues (if relevant)

Fixes https://github.com/mage-os/mageos-magento2/issues/43

### Manual testing scenarios (*)

1. Install Mage-OS 1.0.0
2. Log into the admin
3. Enable admin-analytics in the store configuration
4. Confirm no tracking script is loaded

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
