### PR TITLE
Hide admin-analytics modal if config is disabled

### DIFF
--- a/app/code/Magento/AdminAnalytics/Model/Condition/CanViewNotification.php
+++ b/app/code/Magento/AdminAnalytics/Model/Condition/CanViewNotification.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 namespace Magento\AdminAnalytics\Model\Condition;
 
 use Magento\AdminAnalytics\Model\ResourceModel\Viewer\Logger;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\View\Layout\Condition\VisibilityConditionInterface;
 use Magento\Framework\App\CacheInterface;
 
@@ -41,15 +43,22 @@ class CanViewNotification implements VisibilityConditionInterface
     private $cacheStorage;
 
     /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
      * @param Logger $viewerLogger
      * @param CacheInterface $cacheStorage
      */
     public function __construct(
         Logger $viewerLogger,
-        CacheInterface $cacheStorage
+        CacheInterface $cacheStorage,
+        ScopeConfigInterface $scopeConfig = null
     ) {
         $this->viewerLogger = $viewerLogger;
         $this->cacheStorage = $cacheStorage;
+        $this->scopeConfig = $scopeConfig ?? ObjectManager::getInstance()->get(ScopeConfigInterface::class);
     }
 
     /**
@@ -62,7 +71,7 @@ class CanViewNotification implements VisibilityConditionInterface
     {
         $cacheKey = self::$cachePrefix;
         $value = $this->cacheStorage->load($cacheKey);
-        if ($value !== 'log-exists') {
+        if ($this->scopeConfig->isSetFlag('admin/usage/enabled') && $value !== 'log-exists') {
             $logExists = $this->viewerLogger->checkLogExists();
             if ($logExists) {
                 $this->cacheStorage->save('log-exists', $cacheKey);

--- a/app/code/Magento/AdminAnalytics/Model/Condition/CanViewNotification.php
+++ b/app/code/Magento/AdminAnalytics/Model/Condition/CanViewNotification.php
@@ -50,6 +50,7 @@ class CanViewNotification implements VisibilityConditionInterface
     /**
      * @param Logger $viewerLogger
      * @param CacheInterface $cacheStorage
+     * @param ScopeConfigInterface|null $scopeConfig
      */
     public function __construct(
         Logger $viewerLogger,

--- a/app/code/Magento/AdminAnalytics/Test/Unit/Condition/CanViewNotificationTest.php
+++ b/app/code/Magento/AdminAnalytics/Test/Unit/Condition/CanViewNotificationTest.php
@@ -9,8 +9,8 @@ namespace Magento\AdminAnalytics\Test\Unit\Condition;
 
 use Magento\AdminAnalytics\Model\Condition\CanViewNotification;
 use Magento\AdminAnalytics\Model\ResourceModel\Viewer\Logger;
-use Magento\AdminAnalytics\Model\Viewer\Log;
 use Magento\Framework\App\CacheInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -27,19 +27,19 @@ class CanViewNotificationTest extends TestCase
     /** @var ProductMetadataInterface|MockObject */
     private $productMetadataMock;
 
-    /** @var  Log|MockObject */
-    private $logMock;
-
     /** @var MockObject|CacheInterface $cacheStorageMock */
     private $cacheStorageMock;
+
+    /** @var (ScopeConfigInterface&MockObject)  */
+    private $scopeConfigMock;
 
     protected function setUp(): void
     {
         $this->cacheStorageMock = $this->getMockBuilder(CacheInterface::class)
             ->getMockForAbstractClass();
-        $this->logMock = $this->createMock(Log::class);
         $this->viewerLoggerMock = $this->createMock(Logger::class);
         $this->productMetadataMock = $this->getMockForAbstractClass(ProductMetadataInterface::class);
+        $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
         $objectManager = new ObjectManager($this);
         $this->canViewNotification = $objectManager->getObject(
             CanViewNotification::class,
@@ -47,6 +47,7 @@ class CanViewNotificationTest extends TestCase
                 'viewerLogger' => $this->viewerLoggerMock,
                 'productMetadata' => $this->productMetadataMock,
                 'cacheStorage' => $this->cacheStorageMock,
+                'scopeConfig' => $this->scopeConfigMock,
             ]
         );
     }
@@ -57,7 +58,7 @@ class CanViewNotificationTest extends TestCase
      * @param $logExists
      * @dataProvider isVisibleProvider
      */
-    public function testIsVisibleLoadDataFromLog($expected, $cacheResponse, $logExists)
+    public function testIsVisibleLoadDataFromLog($expected, $cacheResponse, $logExists, $configEnabled)
     {
         $this->cacheStorageMock->expects($this->once())
             ->method('load')
@@ -69,6 +70,7 @@ class CanViewNotificationTest extends TestCase
         $this->cacheStorageMock
             ->method('save')
             ->with('log-exists', 'admin-usage-notification-popup');
+        $this->scopeConfigMock->method('isSetFlag')->with('admin/usage/enabled')->willReturn($configEnabled);
         $this->assertEquals($expected, $this->canViewNotification->isVisible([]));
     }
 
@@ -78,9 +80,10 @@ class CanViewNotificationTest extends TestCase
     public function isVisibleProvider()
     {
         return [
-            [true, false, false],
-            [false, 'log-exists', true],
-            [false, false, true],
+            [true, false, false, true], // first login, no cache, config enabled
+            [false, false, false, false], // first login, no cache, config disabled
+            [false, 'log-exists', true, true], // first login, cache exists, config enabled
+            [false, false, true, true], // first login, cache exists, config enabled
         ];
     }
 }


### PR DESCRIPTION
### Description (*)

Previously, the admin analytics modal was displayed, even if the feature was disabled in the system configuration.



### Related Pull Requests

* [Disable Admin Usage Data Collection by Default](https://github.com/mage-os/mageos-magento2/pull/45)
* [Remove AdminAnalytics Adobe tracking URL](https://github.com/mage-os/mageos-magento2/pull/49)



### Fixed Issues
Fixes https://github.com/mage-os/mageos-magento2/issues/43

### Manual testing scenarios (*)
1. Install Mage-OS 1.0.0
2. Log into the admin
3. Enable admin-analytics in the store configuration
4. Confirm no admin-analytics modal is shown

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
