### PR TITLE
Set admin/usage/enabled default value to false

### DIFF
--- a/app/code/Magento/AdminAnalytics/etc/config.xml
+++ b/app/code/Magento/AdminAnalytics/etc/config.xml
@@ -9,9 +9,7 @@
     <default>
         <admin>
             <usage>
-                <enabled>
-                    0
-                </enabled>
+                <enabled>0</enabled>
             </usage>
         </admin>
     </default>


### PR DESCRIPTION
### Description (*)
Previously the value was evaluated as " 0 ", which is true when used with isSetFlag. Without wrapping space it evaluates correctly to false.

### Related Pull Requests
* [Hide admin-analytics modal if config is disabled](https://github.com/mage-os/mageos-magento2/pull/50)
* [Remove AdminAnalytics Adobe tracking URL](https://github.com/mage-os/mageos-magento2/pull/49)
* [Disable Admin Usage Data Collection by Default](https://github.com/mage-os/mageos-magento2/pull/45)

### Fixed Issues (if relevant)
Closes https://github.com/mage-os/mageos-magento2/issues/43

### Manual testing scenarios (*)
1. Install Mage-OS 1.0.0
2. Log into the admin
3. Enable admin-analytics in the store configuration
4. Confirm no tracking script is loaded

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
