### PR TITLE
Fix customer group extension attributes

### DIFF
--- a/app/code/Magento/Customer/Model/Plugin/GetListCustomerGroupExcludedWebsite.php
+++ b/app/code/Magento/Customer/Model/Plugin/GetListCustomerGroupExcludedWebsite.php
@@ -64,7 +64,10 @@ class GetListCustomerGroupExcludedWebsite
                     $customerGroupId = (int)$customerGroup->getId();
                     if (array_key_exists($customerGroupId, $allExcludedWebsites)) {
                         $excludedWebsites = $allExcludedWebsites[$customerGroupId];
-                        $customerGroupExtensionAttributes = $this->groupExtensionInterfaceFactory->create();
+                        $customerGroupExtensionAttributes = $customerGroup->getExtensionAttributes();
+                        if ($customerGroupExtensionAttributes === null) {
+                            $customerGroupExtensionAttributes = $this->groupExtensionInterfaceFactory->create();
+                        }
                         $customerGroupExtensionAttributes->setExcludeWebsiteIds($excludedWebsites);
                         $customerGroup->setExtensionAttributes($customerGroupExtensionAttributes);
                     }


### PR DESCRIPTION
### Description
This plugin always created a new extension object for customer group lists, regardless of if one already exists. So it overwrote other extension attributes. This change checks if an extension object already exists.

### Manual testing scenarios (*)
Create your own module, introducing another extension attribute for the customer group entity. In this example, an extension attribute named "discount_percentage" is used. 

etc/db_schema.xml:
```
<?xml version="1.0"?>
<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
    <table name="customer_group">
        <column xsi:type="decimal" name="discount_percentage" scale="2" precision="4" unsigned="true"
                nullable="true" default="0" comment="Discount Percentage"/>
    </table>
</schema>
```

etc/extension_attributes.xml:
```
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
    <extension_attributes for="Magento\Customer\Api\Data\GroupInterface">
        <attribute code="discount_percentage" type="float" />
    </extension_attributes>
</config>
```

etc/di.xml:
```
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
    <type name="Magento\Framework\Api\ExtensionAttribute\JoinProcessor">
        <plugin name="customer_group_discount_extension_attribute"
                type="Custom\CustomerGroupDiscount\Plugin\ExtensionAttributeJoinProcessorPlugin"/>
    </type>
</config>
```

Plugin/ExtensionAttributeJoinProcessorPlugin.php:
```
<?php
declare(strict_types=1);

namespace Custom\CustomerGroupDiscount\Plugin;

use Magento\Customer\Api\Data\GroupExtensionInterfaceFactory;
use Magento\Customer\Api\Data\GroupInterface;
use Magento\Framework\Api\ExtensibleDataInterface;
use Magento\Framework\Api\ExtensionAttribute\JoinProcessor;

class ExtensionAttributeJoinProcessorPlugin
{
    public function __construct(
        private readonly GroupExtensionInterfaceFactory $groupExtensionInterfaceFactory
    ) {
    }

    /**
     * Set "discount_percentage" extension attribute based on raw data from database
     */
    public function afterExtractExtensionAttributes(
        JoinProcessor $subject,
        array $result,
        string $extensibleEntityClass,
        array $data
    ): array {
        if ($extensibleEntityClass != ltrim(GroupInterface::class, '\\')) {
            return $result;
        }
        if (!isset($result[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY])) {
            $extensionAttributes = $this->groupExtensionInterfaceFactory->create();
            $result[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY] = $extensionAttributes;
        }
        $result[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]->setDiscountPercentage($data['discount_percentage']);

        return $result;
    }
}
```

Without this PR, the customer group list doesn't contain the extension attribute discount_percentage. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
