### PR TITLE
VCL_recv rework based on closed Magento 2 PR

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -1,5 +1,5 @@
-# VCL version 5.0 is not supported so it should be 4.0 even though actually used Varnish version is 6
-vcl 4.0;
+# The VCL version is not related to the version of Varnish. Use VCL version 4.1 to enforce the use of Varnish 6 or later
+vcl 4.1;
 
 import std;
 # The minimal Varnish version is 6.0
@@ -23,8 +23,31 @@ acl purge {
 }
 
 sub vcl_recv {
-    if (req.restarts > 0) {
-        set req.hash_always_miss = true;
+    # Remove empty query string parameters
+    # e.g.: www.example.com/index.html?
+    if (req.url ~ "\?$") {
+        set req.url = regsub(req.url, "\?$", "");
+    }
+
+    # Remove port number from host header
+    set req.http.Host = regsub(req.http.Host, ":[0-9]+", "");
+
+    # Sorts query string parameters alphabetically for cache normalization purposes
+    set req.url = std.querysort(req.url);
+
+    # Remove the proxy header to mitigate the httpoxy vulnerability
+    # See https://httpoxy.org/
+    unset req.http.proxy;
+
+    # Add X-Forwarded-Proto header when using https
+    if (!req.http.X-Forwarded-Proto && (std.port(server.ip) == 443 || std.port(server.ip) == 8443)) {
+        set req.http.X-Forwarded-Proto = "https";
+    }
+
+    # Reduce grace to the configured setting if the backend is healthy
+    # In case of an unhealthy backend, the original grace is used
+    if (std.healthy(req.backend_hint)) {
+        set req.http.grace = /* {{ grace_period }} */s;
     }
 
     if (req.method == "PURGE") {
@@ -35,7 +58,7 @@ sub vcl_recv {
         # has been added to the response in your backend server config. This is used, for example, by the
         # capistrano-magento2 gem for purging old content from varnish during it's deploy routine.
         if (!req.http.X-Magento-Tags-Pattern && !req.http.X-Pool) {
-            return (synth(400, "X-Magento-Tags-Pattern or X-Pool header required"));
+            return (purge);
         }
         if (req.http.X-Magento-Tags-Pattern) {
           ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern);
@@ -50,10 +73,10 @@ sub vcl_recv {
         req.method != "HEAD" &&
         req.method != "PUT" &&
         req.method != "POST" &&
+        req.method != "PATCH" &&
         req.method != "TRACE" &&
         req.method != "OPTIONS" &&
         req.method != "DELETE") {
-          /* Non-RFC2616 or CONNECT which is weird. */
           return (pipe);
     }
 
@@ -72,33 +95,12 @@ sub vcl_recv {
         return (pass);
     }
 
-    # Set initial grace period usage status
-    set req.http.grace = "none";
-
-    # normalize url in case of leading HTTP scheme and domain
-    set req.url = regsub(req.url, "^http[s]?://", "");
-
-    # collect all cookies
+    # Collapse multiple cookie headers into one
     std.collect(req.http.Cookie);
 
-    # Compression filter. See https://www.varnish-cache.org/trac/wiki/FAQ/Compression
-    if (req.http.Accept-Encoding) {
-        if (req.url ~ "\.(jpg|jpeg|png|gif|gz|tgz|bz2|tbz|mp3|ogg|swf|flv)$") {
-            # No point in compressing these
-            unset req.http.Accept-Encoding;
-        } elsif (req.http.Accept-Encoding ~ "gzip") {
-            set req.http.Accept-Encoding = "gzip";
-        } elsif (req.http.Accept-Encoding ~ "deflate" && req.http.user-agent !~ "MSIE") {
-            set req.http.Accept-Encoding = "deflate";
-        } else {
-            # unknown algorithm
-            unset req.http.Accept-Encoding;
-        }
-    }
-
     # Remove all marketing get parameters to minimize the cache objects
-    if (req.url ~ "(\?|&)(gclid|cx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=") {
-        set req.url = regsuball(req.url, "(gclid|cx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=[-_A-z0-9+()%.]+&?", "");
+    if (req.url ~ "(\?|&)(gclid|cx|_kx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=") {
+        set req.url = regsuball(req.url, "(gclid|cx|_kx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=[-_A-z0-9+()%.]+&?", "");
         set req.url = regsub(req.url, "[?|&]+$", "");
     }
 


### PR DESCRIPTION
### Description
This PR is a rework of the Magento VCL (the vcl_recv part) PR found here:
https://github.com/magento/magento2/pull/36796/files

I left out 2 controversial changes:

- Removing the pass of `/customer` and `/checkout`
   Main reason for this is that, as a hoster (and support on Varnish issues), I see a lot of extensions that accidently remove 
   cache disables. Without this part of the VCL, the result could be a disaster for merchants.
- Removing caching of authenticated GraphQL requests
   Though I understand the reasoning behind this (preventing cache variations), the same technique is used in the frontend.
   I have seen this work perfectly for one of our clients, so I am hesitant to remove something that seemed to be working

PRs for other subroutines will follow (probably weekly)

All credits go to @peterjaap and @ThijsFeryn, I am simpling slicing this up and removing controversial parts to get early approval.

### Related Pull Requests
https://github.com/magento/magento2/pull/36796/files

### Manual testing scenarios
- Load the new VCL
- Test if compression still works
- Test if restarts don't loop anymore
- Test purges without headers

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
