### PR TITLE
Nx Integration Workflow not waiting for called workflow to complete

### DIFF
--- a/.github/workflows/nx-integration-tests.yml
+++ b/.github/workflows/nx-integration-tests.yml
@@ -17,3 +17,13 @@ jobs:
       repository: ${{ github.repository }}
       pr_head: ${{ github.event.pull_request.head.sha }}
       pr_base: ${{ github.event.pull_request.base.ref }}
+
+  wait-for-result:
+    name: Wait For Result
+    needs: call-workflow
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Wait"
+        shell: bash
+        run: |
+          echo "got result"


### PR DESCRIPTION

### Description (*)
When a PR is submited, this repo calls a workflow in the actions repo. The workflow in this repo does not wait for the called repo to complete.
![image](https://github.com/mage-os/mageos-magento2/assets/6369163/b6835a27-1e47-41a6-a4f6-d75d3c0adafe)
Here we can see "Calling Nx Integration Tests" doesn't care about the results of the tests ran from the matrix.

### Related Pull Requests
https://github.com/mage-os/mageos-magento2/actions/runs/7101858336?pr=68

### Fixed Issues (if relevant)
With this in place we should see the following (please note these screenshot were taken from another repo as I can't mimic how this will work until this is in the default branch)

If the matrix jobs complete successfully
![image](https://github.com/mage-os/mageos-magento2/assets/6369163/963e802a-7961-4f85-a4c4-7c302ec52ea3)

If the matrix jobs fail (i.e integration tests fail)
![image](https://github.com/mage-os/mageos-magento2/assets/6369163/db4c1329-374d-485c-8b07-8eadf3638d18)


### Manual testing scenarios (*)
N/A

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
