### PR TITLE
Draft: Fix autochanging stock for new configurable product

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Inventory/ChangeParentStockStatus.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Inventory/ChangeParentStockStatus.php
@@ -76,7 +76,7 @@ class ChangeParentStockStatus
      * @param int $productId
      * @return void
      */
-    private function processStockForParent(int $productId): void
+    public function processStockForParent(int $productId): void
     {
         $criteria = $this->criteriaInterfaceFactory->create();
         $criteria->setScopeFilter($this->stockConfiguration->getDefaultScopeId());

--- a/app/code/Magento/ConfigurableProduct/Model/Inventory/ParentItemProcessor.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Inventory/ParentItemProcessor.php
@@ -53,5 +53,9 @@ class ParentItemProcessor implements ParentItemProcessorInterface
     public function process(Product $product)
     {
         $this->changeParentStockStatus->execute([$product->getId()]);
+
+        if ($product->getTypeId() === Configurable::TYPE_CODE) {
+            $this->changeParentStockStatus->processStockForParent((int) $product->getId());
+        }
     }
 }


### PR DESCRIPTION
### Description

Introduce configurable product stock status assement and update based on it\'s child products. Required while creation of configurable product - as all checks realted to autoset of stock status are executed first on simple product, then on configurable while its creation. This leads to not calling `processStockForParent` method on configurable product - but it should, to set correct stock status for configurable based on child products.

### Fixed Issues

https://github.com/mage-os/mageos-magento2/issues/84
