### PR TITLE
Update incorrect dataprovider for Catalog\SortingTest

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ListProduct/SortingTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ListProduct/SortingTest.php
@@ -437,7 +437,7 @@ class SortingTest extends TestCase
             'default_order_price_desc' => [
                 'sort' => 'price',
                 'direction' => Collection::SORT_ORDER_DESC,
-                'expectation' => ['simple3', 'simple2', 'simple1', 'configurable'],
+                'expectation' => ['configurable', 'simple3', 'simple2', 'simple1'],
             ],
         ];
     }


### PR DESCRIPTION
### Description (*)
update dataset for `testProductListOutOfStockSortOrderWithElasticsearch`. Based on tickets ACP2E-322 and ACP2E-748 - moving down in catalog results out-of-stock configurable items was removed, so data-set needs to be updated accordingly.

### Fixed Issues
* mage-os/mageos-magento2#81