### PR TITLE
GraphQl mutation state check | PlaceOrder and Customer actions - skip list adjustments

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/ApplicationStateComparator/_files/state-skip-list.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/ApplicationStateComparator/_files/state-skip-list.php
@@ -522,6 +522,8 @@ return [
         Magento\GroupedProduct\Model\ResourceModel\Indexer\Stock\Grouped::class => null,
         Magento\Elasticsearch\Model\Adapter\BatchDataMapper\DataMapperResolver::class => null,
         Magento\Elasticsearch\Model\Adapter\Elasticsearch::class => null,
+        Magento\Elasticsearch7\Model\Client\Elasticsearch::class => null,
+        Magento\Elasticsearch\Model\Adapter\BatchDataMapper\ProductDataMapper::class => null,
         Magento\Tax\Model\TaxClass\Source\Product::class => null,
         Magento\Framework\View\TemplateEnginePool::class => null,
         Magento\Framework\View\Element\Template\File\Resolver::class => null,

--- a/dev/tests/integration/framework/Magento/TestFramework/ApplicationStateComparator/_files/state-skip-list.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/ApplicationStateComparator/_files/state-skip-list.php
@@ -522,8 +522,6 @@ return [
         Magento\GroupedProduct\Model\ResourceModel\Indexer\Stock\Grouped::class => null,
         Magento\Elasticsearch\Model\Adapter\BatchDataMapper\DataMapperResolver::class => null,
         Magento\Elasticsearch\Model\Adapter\Elasticsearch::class => null,
-        Magento\Elasticsearch7\Model\Client\Elasticsearch::class => null,
-        Magento\Elasticsearch\Model\Adapter\BatchDataMapper\ProductDataMapper::class => null,
         Magento\Tax\Model\TaxClass\Source\Product::class => null,
         Magento\Framework\View\TemplateEnginePool::class => null,
         Magento\Framework\View\Element\Template\File\Resolver::class => null,
@@ -546,6 +544,22 @@ return [
         Magento\Framework\MessageQueue\Topology\Config\QueueConfigItem::class => null,
         Magento\Framework\MessageQueue\Topology\Config\QueueConfigItem\DataMapper::class => null,
         // phpcs:enable Generic.Files.LineLength.TooLong
+    ],
+    'placeOrder' => [
+        Magento\Elasticsearch7\Model\Client\Elasticsearch::class => null,
+        Magento\Elasticsearch\Model\Adapter\BatchDataMapper\ProductDataMapper::class => null,
+    ],
+    'updateCustomerAddress' => [
+        Magento\Framework\Session\SaveHandler\Redis\Config::class => null,
+        Magento\Framework\Session\SaveHandler\Redis\Logger::class => null,
+    ],
+    'updateCustomerEmail' => [
+        Magento\Framework\Session\SaveHandler\Redis\Config::class => null,
+        Magento\Framework\Session\SaveHandler\Redis\Logger::class => null,
+    ],
+    'updateCustomer' => [
+        Magento\Framework\Session\SaveHandler\Redis\Config::class => null,
+        Magento\Framework\Session\SaveHandler\Redis\Logger::class => null,
     ],
     '' => [
     ],

--- a/dev/tests/integration/framework/Magento/TestFramework/ApplicationStateComparator/_files/state-skip-list.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/ApplicationStateComparator/_files/state-skip-list.php
@@ -549,6 +549,10 @@ return [
         Magento\Elasticsearch7\Model\Client\Elasticsearch::class => null,
         Magento\Elasticsearch\Model\Adapter\BatchDataMapper\ProductDataMapper::class => null,
     ],
+    'createCustomer' => [
+        Magento\Framework\Session\SaveHandler\Redis\Config::class => null,
+        Magento\Framework\Session\SaveHandler\Redis\Logger::class => null,
+    ],
     'updateCustomerAddress' => [
         Magento\Framework\Session\SaveHandler\Redis\Config::class => null,
         Magento\Framework\Session\SaveHandler\Redis\Logger::class => null,


### PR DESCRIPTION
### Description (*)

* Exclude Ealsticsearch classes from mutation state check, as they are going to be used for product reindexation need once indexer state is set OnDemand.
* Exclude Redis client and logger classes from mutation state check for customer create&update operations. Session start with redis is tightly coupled yet with any customer related activity - even in GraphQl. I assume that is in TODO list to resolve by Adobe engeneers.

### Fixed Issues

mage-os/mageos-magento2#82 