### PR TITLE
Fix invalid data-sets for unit tests

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
@@ -44,7 +44,8 @@ return [
         '<?xml version="1.0"?><config><option name="name_one" renderer="123true"><inputType name="name_one"/>' .
         '</option></config>',
         [
-            "Element 'option', attribute 'renderer': [facet 'pattern'] The value '123true' is not accepted by the pattern '([\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Element 'option', attribute 'renderer': [facet 'pattern'] The value '123true' is not accepted " .
+            "by the pattern '([\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><option name=\"name_one\" " .
             "renderer=\"123true\"><inputType name=\"name_one\"/></option></config>\n2:\n"
         ],

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
@@ -44,7 +44,7 @@ return [
         '<?xml version="1.0"?><config><option name="name_one" renderer="123true"><inputType name="name_one"/>' .
         '</option></config>',
         [
-            "Element 'option', attribute 'renderer': '123true' is not a valid value of the atomic type 'modelName'.\n" .
+            "Element 'option', attribute 'renderer': [facet 'pattern'] The value '123true' is not accepted by the pattern '([\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><option name=\"name_one\" " .
             "renderer=\"123true\"><inputType name=\"name_one\"/></option></config>\n2:\n"
         ],

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
@@ -32,7 +32,8 @@ return [
     'type_modelinstance_invalid_value' => [
         '<?xml version="1.0"?><config><type name="some_name" modelInstance="123" /></config>',
         [
-            "Element 'type', attribute 'modelInstance': [facet 'pattern'] The value '123' is not accepted by the pattern '([\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Element 'type', attribute 'modelInstance': [facet 'pattern'] The value '123' is not " .
+            "accepted by the pattern '([\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type name=\"some_name\" " .
             "modelInstance=\"123\"/></config>\n2:\n"
         ],
@@ -71,7 +72,8 @@ return [
     'type_pricemodel_instance_invalid_value' => [
         '<?xml version="1.0"?><config><type name="some_name"><priceModel instance="123123" /></type></config>',
         [
-            "Element 'priceModel', attribute 'instance': [facet 'pattern'] The value '123123' is not accepted by the pattern '([\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Element 'priceModel', attribute 'instance': [facet 'pattern'] The value '123123' is not accepted " .
+            "by the pattern '([\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type " .
             "name=\"some_name\"><priceModel instance=\"123123\"/></type></config>\n2:\n"
         ],
@@ -79,7 +81,8 @@ return [
     'type_indexermodel_instance_invalid_value' => [
         '<?xml version="1.0"?><config><type name="some_name"><indexerModel instance="123" /></type></config>',
         [
-            "Element 'indexerModel', attribute 'instance': [facet 'pattern'] The value '123' is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Element 'indexerModel', attribute 'instance': [facet 'pattern'] The value '123' is not accepted " .
+            "by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type " .
             "name=\"some_name\"><indexerModel instance=\"123\"/></type></config>\n2:\n"
         ],
@@ -102,7 +105,8 @@ return [
     'stockindexermodel_instance_invalid_value' => [
         '<?xml version="1.0"?><config><type name="some_name"><stockIndexerModel instance="1234"/></type></config>',
         [
-            "Element 'stockIndexerModel', attribute 'instance': [facet 'pattern'] The value '1234' is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Element 'stockIndexerModel', attribute 'instance': [facet 'pattern'] The value '1234' is not accepted " .
+            "by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type " .
             "name=\"some_name\"><stockIndexerModel instance=\"1234\"/></type></config>\n2:\n"
         ],

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
@@ -32,7 +32,7 @@ return [
     'type_modelinstance_invalid_value' => [
         '<?xml version="1.0"?><config><type name="some_name" modelInstance="123" /></config>',
         [
-            "Element 'type', attribute 'modelInstance': '123' is not a valid value of the atomic type 'modelName'.\n" .
+            "Element 'type', attribute 'modelInstance': [facet 'pattern'] The value '123' is not accepted by the pattern '([\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type name=\"some_name\" " .
             "modelInstance=\"123\"/></config>\n2:\n"
         ],
@@ -71,16 +71,16 @@ return [
     'type_pricemodel_instance_invalid_value' => [
         '<?xml version="1.0"?><config><type name="some_name"><priceModel instance="123123" /></type></config>',
         [
-            "Element 'priceModel', attribute 'instance': '123123' is not a valid value of the atomic " .
-            "type 'modelName'.\nLine: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type " .
+            "Element 'priceModel', attribute 'instance': [facet 'pattern'] The value '123123' is not accepted by the pattern '([\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type " .
             "name=\"some_name\"><priceModel instance=\"123123\"/></type></config>\n2:\n"
         ],
     ],
     'type_indexermodel_instance_invalid_value' => [
         '<?xml version="1.0"?><config><type name="some_name"><indexerModel instance="123" /></type></config>',
         [
-            "Element 'indexerModel', attribute 'instance': '123' is not a valid value of the atomic type " .
-            "'modelName'.\nLine: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type " .
+            "Element 'indexerModel', attribute 'instance': [facet 'pattern'] The value '123' is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type " .
             "name=\"some_name\"><indexerModel instance=\"123\"/></type></config>\n2:\n"
         ],
     ],
@@ -102,8 +102,8 @@ return [
     'stockindexermodel_instance_invalid_value' => [
         '<?xml version="1.0"?><config><type name="some_name"><stockIndexerModel instance="1234"/></type></config>',
         [
-            "Element 'stockIndexerModel', attribute 'instance': '1234' is not a valid value of the atomic type " .
-            "'modelName'.\nLine: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type " .
+            "Element 'stockIndexerModel', attribute 'instance': [facet 'pattern'] The value '1234' is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><type " .
             "name=\"some_name\"><stockIndexerModel instance=\"1234\"/></type></config>\n2:\n"
         ],
     ],

--- a/app/code/Magento/Config/Test/Unit/Model/Config/_files/invalidSystemXmlArray.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/_files/invalidSystemXmlArray.php
@@ -90,7 +90,8 @@ return [
             "1:<config><system><section id=\"section1\"><group id=\"group1\"><label>Label</label><field " .
             "id=\"field_id\"><config_path>co</config_path></field></group><group id=\"group2\"><label>" .
             "Label_One</label></group></section></system></config>\n2:\n",
-            "Element 'config_path': 'co' is not a valid value of the atomic type 'typeConfigPath'.\nLine: 1\n" .
+            "Element 'config_path': [facet 'minLength'] The value has a length of '2'; " .
+            "this underruns the allowed minimum length of '5'.\nLine: 1\n" .
             "The xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><system><section id=\"section1\"><group " .
             "id=\"group1\"><label>Label</label><field id=\"field_id\"><config_path>co</config_path></field>" .
             "</group><group id=\"group2\"><label>Label_One</label></group></section></system></config>\n2:\n"
@@ -107,7 +108,8 @@ return [
             "1:<config><system><section id=\"section1\"><group id=\"group1\"><label>Label</label><field " .
             "id=\"field_id\"><if_module_enabled>Som</if_module_enabled></field></group><group id=\"group2\">" .
             "<label>Label_One</label></group></section></system></config>\n2:\n",
-            "Element 'if_module_enabled': 'Som' is not a valid value of the atomic type 'typeModule'.\n" .
+            "Element 'if_module_enabled': [facet 'minLength'] The value has a length of '3'; " .
+            "this underruns the allowed minimum length of '5'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><system><section id=\"section1\">" .
             "<group id=\"group1\"><label>Label</label><field id=\"field_id\"><if_module_enabled>Som" .
             "</if_module_enabled></field></group><group id=\"group2\"><label>Label_One</label></group>" .

--- a/app/code/Magento/Directory/Test/Unit/Model/CurrencyTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/CurrencyTest.php
@@ -139,7 +139,7 @@ class CurrencyTest extends TestCase
     public function getOutputFormatDataProvider(): array
     {
         $ar_DZ = "\u{062C}.\u{0645}.\u{200F}\u{00A0}%s";
-        if (version_compare(PHP_VERSION, '8.3', '>=')) {
+        if (version_compare(PHP_VERSION, '8.2', '>=')) {
             $ar_DZ = "%s\u{00A0}\u{062C}.\u{0645}.\u{200F}";
         }
         return [

--- a/app/code/Magento/Directory/Test/Unit/Model/CurrencyTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/CurrencyTest.php
@@ -138,16 +138,12 @@ class CurrencyTest extends TestCase
      */
     public function getOutputFormatDataProvider(): array
     {
-        $ar_DZ = "\u{062C}.\u{0645}.\u{200F}\u{00A0}%s";
-        if (version_compare(PHP_VERSION, '8.2', '>=')) {
-            $ar_DZ = "%s\u{00A0}\u{062C}.\u{0645}.\u{200F}";
-        }
         return [
             'en_US:USD' => ['en_US', 'USD', '$%s'],
             'en_US:PLN' => ['en_US', 'PLN', "PLN\u{00A0}%s"],
             'en_US:PKR' => ['en_US', 'PKR', "PKR\u{00A0}%s"],
             'af_ZA:VND' => ['af_ZA', 'VND', "\u{20AB}%s"],
-            'ar_DZ:EGP' => ['ar_DZ', 'EGP', $ar_DZ],
+            'ar_DZ:EGP' => ['ar_DZ', 'EGP', "%s\u{00A0}\u{062C}.\u{0645}.\u{200F}"],
             'ar_SA:USD' => ['ar_SA', 'USD', "%s\u{00A0}US$"],
             'ar_SA:LBP' => ['ar_SA', 'LBP', "%s\u{00A0}\u{0644}.\u{0644}.\u{200F}"],
             'fa_IR:USD' => ['fa_IR', 'USD', "\u{200E}$%s"],

--- a/app/code/Magento/Email/Test/Unit/Model/Template/Config/XsdTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/Config/XsdTest.php
@@ -143,8 +143,9 @@ class XsdTest extends TestCase
             'node "template" with invalid attribute "area"' => [
                 '<config><template id="test" label="Test" file="test.txt" type="text" module="Module" area="invalid"/></config>',
                 [
-                    "Element 'template', attribute 'area': 'invalid' is not a valid value of the atomic type " .
-                    "'areaType'.The xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><template id=\"test\" " .
+                    "Element 'template', attribute 'area': [facet 'enumeration'] The value 'invalid' is not " .
+                    "an element of the set {'frontend', 'adminhtml'}.The xml was: \n" .
+                    "0:<?xml version=\"1.0\"?>\n1:<config><template id=\"test\" " .
                     "label=\"Test\" file=\"test.txt\" type=\"text\" module=\"Module\" area=\"invalid\"/>" .
                     "</config>\n2:\n",
                 ],

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Export/Config/_files/invalidExportXmlArray.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Export/Config/_files/invalidExportXmlArray.php
@@ -26,17 +26,14 @@ return [
     ],
     'attributes_with_type_modelName_and_invalid_value' => [
         '<?xml version="1.0"?><config><entity name="Name/one" model="model_one" '
-            . 'entityAttributeFilterType="model_one"/><entityType entity="Name/one" name="name_one" model="1"/>'
-            . ' <fileFormat name="name_one" model="1model"/></config>',
+        . 'entityAttributeFilterType="model_one"/><entityType entity="Name/one" name="name_one" model="1"/>'
+        . ' <fileFormat name="name_one" model="1model"/></config>',
         [
-            "Element 'entityType', attribute 'model': '1' is not a valid value of the atomic type 'modelName'.\n" .
-            "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity name=\"Name/one\" " .
-            "model=\"model_one\" entityAttributeFilterType=\"model_one\"/><entityType entity=\"Name/one\" " .
-            "name=\"name_one\" model=\"1\"/> <fileFormat name=\"name_one\" model=\"1model\"/></config>\n2:\n",
-            "Element 'fileFormat', attribute 'model': '1model' is not a valid value of the atomic type 'modelName'.\n" .
-            "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity name=\"Name/one\" " .
-            "model=\"model_one\" entityAttributeFilterType=\"model_one\"/><entityType entity=\"Name/one\" " .
-            "name=\"name_one\" model=\"1\"/> <fileFormat name=\"name_one\" model=\"1model\"/></config>\n2:\n"
+            "Element 'fileFormat', attribute 'model': [facet 'pattern'] The value '1model'" .
+            " is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity name=\"Name/one\"" .
+            " model=\"model_one\" entityAttributeFilterType=\"model_one\"/><entityType entity=\"Name/one\"" .
+            " name=\"name_one\" model=\"1\"/> <fileFormat name=\"name_one\" model=\"1model\"/></config>\n2:\n"
         ],
     ],
     'productType_node_with_required_attribute' => [

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportMergedXmlArray.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportMergedXmlArray.php
@@ -51,7 +51,8 @@ return [
         '<?xml version="1.0"?><config><entity name="test_name" label="test_label" model="34afwer" ' .
         'behaviorModel="test" /></config>',
         [
-            "Element 'entity', attribute 'model': '34afwer' is not a valid value of the atomic type 'modelName'.\n" .
+            "Element 'entity', attribute 'model': [facet 'pattern'] The value '34afwer'" .
+            " is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity name=\"test_name\" " .
             "label=\"test_label\" model=\"34afwer\" behaviorModel=\"test\"/></config>\n2:\n"
         ],
@@ -60,8 +61,9 @@ return [
         '<?xml version="1.0"?><config><entity name="test_name" label="test_label" model="test" behaviorModel="666" />' .
         '</config>',
         [
-            "Element 'entity', attribute 'behaviorModel': '666' is not a valid value of the atomic type " .
-            "'modelName'.\nLine: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity " .
+            "Element 'entity', attribute 'behaviorModel': [facet 'pattern'] The value '666'" .
+            " is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity " .
             "name=\"test_name\" label=\"test_label\" model=\"test\" behaviorModel=\"666\"/></config>\n2:\n"
         ],
     ]

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportXmlArray.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportXmlArray.php
@@ -24,17 +24,17 @@ return [
     'entity_with_invalid_model_value' => [
         '<?xml version="1.0"?><config><entity name="some_name" model="12345"/></config>',
         [
-            "Element 'entity', attribute 'model': '12345' is not a valid value of the atomic type 'modelName'.\n" .
-            "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity name=\"some_name\" " .
-            "model=\"12345\"/></config>\n2:\n"
-
+            "Element 'entity', attribute 'model': [facet 'pattern'] The value '12345' is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity name=\"some_name\"" .
+            " model=\"12345\"/></config>\n2:\n"
         ],
     ],
     'entity_with_invalid_behaviormodel_value' => [
         '<?xml version="1.0"?><config><entity name="some_name" behaviorModel="=--09"/></config>',
         [
-            "Element 'entity', attribute 'behaviorModel': '=--09' is not a valid value of the atomic type " .
-            "'modelName'.\nLine: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity " .
+            "Element 'entity', attribute 'behaviorModel': [facet 'pattern'] The value '=--09'" .
+            " is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity " .
             "name=\"some_name\" behaviorModel=\"=--09\"/></config>\n2:\n"
         ],
     ],
@@ -65,7 +65,8 @@ return [
     'entitytype_with_invalid_model_attribute_value' => [
         '<?xml version="1.0"?><config><entityType entity="entity_name" name="some_name" model="1test"/></config>',
         [
-            "Element 'entityType', attribute 'model': '1test' is not a valid value of the atomic type 'modelName'.\n" .
+            "Element 'entityType', attribute 'model': [facet 'pattern'] The value '1test'" .
+            " is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n" .
             "1:<config><entityType entity=\"entity_name\" name=\"some_name\" model=\"1test\"/></config>\n2:\n"
         ],

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportXmlArray.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportXmlArray.php
@@ -24,7 +24,8 @@ return [
     'entity_with_invalid_model_value' => [
         '<?xml version="1.0"?><config><entity name="some_name" model="12345"/></config>',
         [
-            "Element 'entity', attribute 'model': [facet 'pattern'] The value '12345' is not accepted by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
+            "Element 'entity', attribute 'model': [facet 'pattern'] The value '12345' is not accepted " .
+            "by the pattern '([\\\\]?[a-zA-Z_][a-zA-Z0-9_]*)+'.\n" .
             "Line: 1\nThe xml was: \n0:<?xml version=\"1.0\"?>\n1:<config><entity name=\"some_name\"" .
             " model=\"12345\"/></config>\n2:\n"
         ],

--- a/app/code/Magento/Integration/Test/Unit/Model/Config/XsdTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/Config/XsdTest.php
@@ -349,8 +349,9 @@ class XsdTest extends TestCase
                     </integration>
                 </integrations>',
                 [
-                    "Element 'integration', attribute 'name': '' is not a valid value of the atomic type " .
-                    "'integrationNameType'.The xml was: \n0:<?xml version=\"1.0\"?>\n1:<integrations>\n" .
+                    "Element 'integration', attribute 'name': [facet 'minLength'] The value '' has a " .
+                    "length of '0'; this underruns the allowed minimum length of '2'.The xml was: \n" .
+                    "0:<?xml version=\"1.0\"?>\n1:<integrations>\n" .
                     "2:                    <integration name=\"\">\n3:                        <email>" .
                     "test-integration1@magento.com</email>\n4:                        <endpoint_url>" .
                     "http://endpoint.url</endpoint_url>\n5:                        <identity_link_url>" .
@@ -368,7 +369,8 @@ class XsdTest extends TestCase
                     </integration>
                 </integrations>',
                 [
-                    "Element 'email': 'invalid' is not a valid value of the atomic type 'emailType'.The xml was: \n" .
+                    "Element 'email': [facet 'pattern'] The value 'invalid' is not accepted by " .
+                    "the pattern '[^@]+@[^\.]+\..+'.The xml was: \n" .
                     "0:<?xml version=\"1.0\"?>\n1:<integrations>\n2:                    <integration " .
                     "name=\"TestIntegration1\">\n3:                        <email>invalid</email>\n" .
                     "4:                        <endpoint_url>http://endpoint.url</endpoint_url>\n" .

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Pdf/Config/XsdTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Pdf/Config/XsdTest.php
@@ -188,7 +188,8 @@ class XsdTest extends TestCase
             'non-valid empty renderer class name' => [
                 '<config><renderers><page type="p1"><renderer product_type="prt1"/></page></renderers></config>',
                 [
-                    "Element 'renderer': '' is not a valid value of the atomic type 'classNameType'.The xml was: \n" .
+                    "Element 'renderer': [facet 'pattern'] The value '' is not accepted by the pattern " .
+                    "'[A-Z][a-zA-Z\d]*(\\\\[A-Z][a-zA-Z\d]*)*'.The xml was: \n" .
                     "0:<?xml version=\"1.0\"?>\n1:<config><renderers><page type=\"p1\"><renderer " .
                     "product_type=\"prt1\"/></page></renderers></config>\n2:\n"
                 ],
@@ -256,8 +257,9 @@ class XsdTest extends TestCase
                 '<config><totals><total name="i1"><title>Title</title><source_field>foo</source_field>' .
                 '<model>a model</model></total></totals></config>',
                 [
-                    "Element 'model': 'a model' is not a valid value of the atomic type 'classNameType'.The xml " .
-                    "was: \n0:<?xml version=\"1.0\"?>\n1:<config><totals><total name=\"i1\"><title>Title</title>" .
+                    "Element 'model': [facet 'pattern'] The value 'a model' is not accepted by the pattern " .
+                    "'[A-Z][a-zA-Z\d]*(\\\\[A-Z][a-zA-Z\d]*)*'.The xml was: \n" .
+                    "0:<?xml version=\"1.0\"?>\n1:<config><totals><total name=\"i1\"><title>Title</title>" .
                     "<source_field>foo</source_field><model>a model</model></total></totals></config>\n2:\n"
                 ],
             ],

--- a/lib/internal/Magento/Framework/MessageQueue/Test/Unit/Consumer/Config/XsdTest.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Test/Unit/Consumer/Config/XsdTest.php
@@ -106,14 +106,14 @@ class XsdTest extends TestCase
                     <consumer name="consumer5" queue="queue4"/>
                 </config>',
                 [
-                    "Element 'consumer', attribute 'handler': 'handlerClass_One1::handlerMethod1' is not a valid value of the atomic type 'handlerType'.The xml was: \n" .
+                    "Element 'consumer', attribute 'handler': [facet 'pattern'] The value 'handlerClass_One1::handlerMethod1' is not accepted by the pattern '[a-zA-Z0-9\\\\]+::[a-zA-Z0-9]+'.The xml was: \n" .
                     "0:<?xml version=\"1.0\"?>\n1:<config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"urn:magento:framework-message-queue:etc/consumer.xsd\">\n" .
                     "2:                    <consumer name=\"consumer1\" queue=\"queue1\" handler=\"handlerClass_One1::handlerMethod1\" consumerInstance=\"consumerClass1\" connection=\"amqp\" maxMessages=\"100\" maxIdleTime=\"500\" sleep=\"2\" onlySpawnWhenMessageAvailable=\"true\"/>\n" .
                     "3:                    <consumer name=\"consumer2\" queue=\"queue2\" handler=\"handlerClassOne2::handler_Method2\" consumerInstance=\"consumerClass2\" connection=\"db\"/>\n" .
                     "4:                    <consumer name=\"consumer3\" queue=\"queue3\" handler=\"handlerClassThree::handlerMethodThree\" consumerInstance=\"consumerClass3\"/>\n" .
                     "5:                    <consumer name=\"consumer4\" queue=\"queue4\" handler=\"handlerClassFour::handlerMethodFour\"/>\n" .
                     "6:                    <consumer name=\"consumer5\" queue=\"queue4\"/>\n7:                </config>\n8:\n",
-                    "Element 'consumer', attribute 'handler': 'handlerClassOne2::handler_Method2' is not a valid value of the atomic type 'handlerType'.The xml was: \n" .
+                    "Element 'consumer', attribute 'handler': [facet 'pattern'] The value 'handlerClassOne2::handler_Method2' is not accepted by the pattern '[a-zA-Z0-9\\\\]+::[a-zA-Z0-9]+'.The xml was: \n" .
                     "0:<?xml version=\"1.0\"?>\n1:<config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"urn:magento:framework-message-queue:etc/consumer.xsd\">\n" .
                     "2:                    <consumer name=\"consumer1\" queue=\"queue1\" handler=\"handlerClass_One1::handlerMethod1\" consumerInstance=\"consumerClass1\" connection=\"amqp\" maxMessages=\"100\" maxIdleTime=\"500\" sleep=\"2\" onlySpawnWhenMessageAvailable=\"true\"/>\n" .
                     "3:                    <consumer name=\"consumer2\" queue=\"queue2\" handler=\"handlerClassOne2::handler_Method2\" consumerInstance=\"consumerClass2\" connection=\"db\"/>\n" .
@@ -280,13 +280,15 @@ class XsdTest extends TestCase
                     </broker>
                 </config>',
                 [
-                    "Element 'queue', attribute 'handler': 'handlerClass_One1::handlerMethod1' is not a valid value of the atomic type 'handlerType'.The xml was: \n" .
+                    "Element 'queue', attribute 'handler': [facet 'pattern'] The value " .
+                    "'handlerClass_One1::handlerMethod1' is not accepted by the pattern '[a-zA-Z0-9\\\\]+::[a-zA-Z0-9]+'.The xml was: \n" .
                     "0:<?xml version=\"1.0\"?>\n1:<config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"urn:magento:framework-message-queue:etc/queue.xsd\">\n" .
                     "2:                    <broker topic=\"asd\">\n" .
                     "3:                        <queue name=\"queue1\" consumer=\"consumer1\" handler=\"handlerClass_One1::handlerMethod1\" consumerInstance=\"consumerClass1\" maxMessages=\"5\"/>\n" .
                     "4:                        <queue name=\"queue2\" consumer=\"consumer2\" handler=\"handlerClassOne2::handler_Method2\" consumerInstance=\"consumerClass2\" maxMessages=\"5\"/>\n" .
                     "5:                    </broker>\n6:                </config>\n7:\n",
-                    "Element 'queue', attribute 'handler': 'handlerClassOne2::handler_Method2' is not a valid value of the atomic type 'handlerType'.The xml was: \n" .
+                    "Element 'queue', attribute 'handler': [facet 'pattern'] The value " .
+                    "'handlerClassOne2::handler_Method2' is not accepted by the pattern '[a-zA-Z0-9\\\\]+::[a-zA-Z0-9]+'.The xml was: \n" .
                     "0:<?xml version=\"1.0\"?>\n1:<config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"urn:magento:framework-message-queue:etc/queue.xsd\">\n" .
                     "2:                    <broker topic=\"asd\">\n" .
                     "3:                        <queue name=\"queue1\" consumer=\"consumer1\" handler=\"handlerClass_One1::handlerMethod1\" consumerInstance=\"consumerClass1\" maxMessages=\"5\"/>\n" .
@@ -302,13 +304,15 @@ class XsdTest extends TestCase
                     </broker>
                 </config>',
                 [
-                    "Element 'queue', attribute 'consumerInstance': 'consumer_Class1' is not a valid value of the atomic type 'instanceType'.The xml was: \n" .
+                    "Element 'queue', attribute 'consumerInstance': [facet 'pattern'] The value 'consumer_Class1' " .
+                    "is not accepted by the pattern '[a-zA-Z0-9\\\\]+'.The xml was: \n" .
                     "0:<?xml version=\"1.0\"?>\n1:<config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"urn:magento:framework-message-queue:etc/queue.xsd\">\n" .
                     "2:                     <broker topic=\"asd\">\n" .
                     "3:                        <queue name=\"queue1\" consumer=\"consumer1\" handler=\"handlerClassOne1::handlerMethod1\" consumerInstance=\"consumer_Class1\" maxMessages=\"5\"/>\n" .
                     "4:                        <queue name=\"queue2\" consumer=\"consumer2\" handler=\"handlerClassOne2::handlerMethod2\" consumerInstance=\"consumerClass_2\" maxMessages=\"5\"/>\n" .
                     "5:                    </broker>\n6:                </config>\n7:\n",
-                    "Element 'queue', attribute 'consumerInstance': 'consumerClass_2' is not a valid value of the atomic type 'instanceType'.The xml was: \n" .
+                    "Element 'queue', attribute 'consumerInstance': [facet 'pattern'] The value 'consumerClass_2' " .
+                    "is not accepted by the pattern '[a-zA-Z0-9\\\\]+'.The xml was: \n" .
                     "0:<?xml version=\"1.0\"?>\n1:<config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"urn:magento:framework-message-queue:etc/queue.xsd\">\n" .
                     "2:                     <broker topic=\"asd\">\n" .
                     "3:                        <queue name=\"queue1\" consumer=\"consumer1\" handler=\"handlerClassOne1::handlerMethod1\" consumerInstance=\"consumer_Class1\" maxMessages=\"5\"/>\n" .


### PR DESCRIPTION
### Description (*)

Fix unit tests for these modules:
* ImportExport
* Framework\MessageQueue
* Sales
* Integration
* Email

After these changes - unit tests should be failed due to mysterious reasons.

#### Reasons why tests were failed

XSD schema got changed. But it was not represented in Unit Tests.