### PR TITLE
Split Magento and Mage-OS versions in ProductMetadata for compatibility

### DIFF
--- a/app/code/Magento/Backend/Block/Page/Footer.php
+++ b/app/code/Magento/Backend/Block/Page/Footer.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Backend\Block\Page;
 
+use Magento\Framework\App\DistributionMetadataInterface;
+
 /**
  * Adminhtml footer block
  *
@@ -20,7 +22,7 @@ class Footer extends \Magento\Backend\Block\Template
     protected $_template = 'Magento_Backend::page/footer.phtml';
 
     /**
-     * @var \Magento\Framework\App\ProductMetadataInterface
+     * @var \Magento\Framework\App\ProductMetadataInterface|DistributionMetadataInterface
      * @since 100.1.0
      */
     protected $productMetadata;
@@ -55,7 +57,17 @@ class Footer extends \Magento\Backend\Block\Template
      */
     public function getMagentoVersion()
     {
-        return $this->productMetadata->getVersion();
+        return $this->productMetadata->getDistributionVersion();
+    }
+
+    /**
+     * Get product name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->productMetadata->getName();
     }
 
     /**

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/footer.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/footer.phtml
@@ -11,6 +11,6 @@ use Magento\Framework\Escaper;
 /** @var Footer $block */
 ?>
 <p class="magento-version">
-    <strong><?= $escaper->escapeHtml(__('Mage-OS')); ?></strong>
+    <strong><?= $escaper->escapeHtml(__($block->getName())); ?></strong>
     <?= $escaper->escapeHtml(__('ver. %1', $block->getMagentoVersion())); ?>
 </p>

--- a/app/code/Magento/Version/Controller/Index/Index.php
+++ b/app/code/Magento/Version/Controller/Index/Index.php
@@ -10,6 +10,7 @@ namespace Magento\Version\Controller\Index;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\DistributionMetadataInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Controller\Result\RawFactory as RawResponseFactory;
 
@@ -21,7 +22,7 @@ class Index extends Action implements HttpGetActionInterface
     public const DEV_PREFIX = 'dev-';
 
     /**
-     * @var ProductMetadataInterface
+     * @var ProductMetadataInterface|DistributionMetadataInterface
      */
     private $productMetadata;
 
@@ -52,7 +53,7 @@ class Index extends Action implements HttpGetActionInterface
     {
         $rawResponse = $this->rawFactory->create();
 
-        $version = $this->productMetadata->getVersion() ?? '';
+        $version = $this->productMetadata->getDistributionVersion() ?? '';
         $versionParts = explode('.', $version);
         if (!$this->isGitBasedInstallation($version) && $this->isCorrectVersion($versionParts)) {
             $rawResponse->setContents(

--- a/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
+++ b/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
@@ -6,6 +6,7 @@
 namespace Magento\Webapi\Model\Rest\Swagger;
 
 use Magento\Framework\Api\SimpleDataObjectConverter;
+use Magento\Framework\App\DistributionMetadataInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Reflection\TypeProcessor;
 use Magento\Framework\Webapi\Authorization;
@@ -52,7 +53,7 @@ class Generator extends AbstractSchemaGenerator
     /**
      * Magento product metadata
      *
-     * @var ProductMetadataInterface
+     * @var ProductMetadataInterface|DistributionMetadataInterface
      */
     protected ProductMetadataInterface $productMetadata;
 
@@ -182,7 +183,7 @@ class Generator extends AbstractSchemaGenerator
      */
     protected function getGeneralInfo()
     {
-        $versionParts = explode('.', $this->productMetadata->getVersion());
+        $versionParts = explode('.', $this->productMetadata->getDistributionVersion());
         if (!isset($versionParts[0]) || !isset($versionParts[1])) {
             return []; // Major and minor version are not set - return empty response
         }

--- a/dev/tests/integration/testsuite/Magento/Version/Controller/Index/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Version/Controller/Index/IndexTest.php
@@ -19,7 +19,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractController
         $name = $productMetadata->getName();
         $edition = $productMetadata->getEdition();
 
-        $fullVersion = $productMetadata->getVersion();
+        $fullVersion = $productMetadata->getDistributionVersion();
         if ($this->isComposerBasedInstallation($fullVersion)) {
             $versionParts = explode('.', $fullVersion);
             $majorMinor = $versionParts[0] . '.' . $versionParts[1];

--- a/lib/internal/Magento/Framework/App/DistributionMetadataInterface.php
+++ b/lib/internal/Magento/Framework/App/DistributionMetadataInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\App;
+
+/**
+ * Magento application product metadata
+ *
+ * @api
+ * @since 100.0.2
+ */
+interface DistributionMetadataInterface
+{
+    /**
+     * Get Distribution version
+     *
+     * @return string
+     */
+    public function getDistributionVersion();
+
+    /**
+     * Get Product name
+     *
+     * @return string
+     */
+    public function getProductName();
+}

--- a/lib/internal/Magento/Framework/Composer/ComposerInformation.php
+++ b/lib/internal/Magento/Framework/Composer/ComposerInformation.php
@@ -246,7 +246,8 @@ class ComposerInformation
                 $packages[$package->getName()] = [
                     'name' => $package->getName(),
                     'type' => $package->getType(),
-                    'version' => $package->getPrettyVersion()
+                    'version' => $package->getPrettyVersion(),
+                    'magento_version' => $package->getExtra()['magento_version'] ?? null,
                 ];
             }
         }

--- a/lib/internal/Magento/Framework/Console/Cli.php
+++ b/lib/internal/Magento/Framework/Console/Cli.php
@@ -9,6 +9,7 @@ namespace Magento\Framework\Console;
 
 use Magento\Framework\App\Bootstrap;
 use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\DistributionMetadataInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ProductMetadata;
 use Magento\Framework\Composer\ComposerJsonFinder;
@@ -69,6 +70,11 @@ class Cli extends Console\Application
     private $logger;
 
     /**
+     * @var ProductMetadata
+     */
+    private $productMetadata;
+
+    /**
      * @param string $name the application name
      * @param string $version the application version
      */
@@ -97,8 +103,9 @@ class Cli extends Console\Application
         if ($version == 'UNKNOWN') {
             $directoryList = new DirectoryList(BP);
             $composerJsonFinder = new ComposerJsonFinder($directoryList);
-            $productMetadata = new ProductMetadata($composerJsonFinder);
-            $version = $productMetadata->getVersion();
+            $this->productMetadata = new ProductMetadata($composerJsonFinder);
+            $name = $this->productMetadata->getName() . ' CLI';
+            $version = $this->productMetadata->getDistributionVersion();
         }
 
         parent::__construct($name, $version);
@@ -231,5 +238,26 @@ class Cli extends Console\Application
         }
 
         return array_merge([], ...$commands);
+    }
+
+    /**
+     * Get system version info.
+     *
+     * @return string
+     */
+    public function getLongVersion()
+    {
+        if (isset($this->productMetadata)
+            && $this->productMetadata instanceof DistributionMetadataInterface
+            && $this->productMetadata->getDistributionVersion() !== $this->productMetadata->getVersion()) {
+            return sprintf(
+                '%s (based on %s %s)',
+                parent::getLongVersion(),
+                $this->productMetadata->getProductName(),
+                $this->productMetadata->getVersion()
+            );
+        }
+
+        return parent::getLongVersion();
     }
 }

--- a/setup/index.php
+++ b/setup/index.php
@@ -41,7 +41,7 @@ $metaClass = $objectManager->create(ProductMetadata::class);
 /** @var License $license */
 $license = $licenseClass->getContents();
 /** @var ProductMetadata $version */
-$version = $metaClass->getVersion();
+$version = $metaClass->getDistributionVersion();
 
 $request = new Request();
 $basePath = $request->getBasePath();


### PR DESCRIPTION
<!---
    Thank you for contributing to Mage-OS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Some extensions use version comparison in Magento to determine what code to run. This is a problem for Mage-OS, where we replace Magento's getVersion() number (IE 2.4.7) with the Mage-OS version (IE 1.0.5), which makes some extensions think it's an old version of Magento and run old incompatible code.

The idea here is:

- Magento gets the version from composer.lock for magento/product-community-edition, via https://github.com/rhoerr/mageos-magento2/blob/7bed30c9ea2b6e31130d4cead3e191871fb9b98e/lib/internal/Magento/Framework/App/ProductMetadata.php#L118
- Mage-OS replaces that version number during our existing build/release process.
- To fix it, we change getVersion to return the equivalent Magento version, and add a separate method to get the Mage-OS version.
- https://github.com/mage-os/generate-mirror-repo-js/pull/189 will store the upstream version as `extra.magento_version` on the product metapackage composer JSON, which is stored in composer.lock and already read by Magento.
- `getVersion()` (via `getSystemPackageVersion()`) is changed to read that upstream version (like 2.4.7-p3), for intercompatibility with Magento. That will return the equivalent version for releases going forward. Side benefit: it'll be easier to know what the equivalent version being run actually is.
- A new `getDistributionVersion()` (via `getSystemDistroVersion()`) will return the distribution version (like 1.0.5), from the metapackage version. If any code needs to know the exact Mage-OS version, it can use this to get it.
- All references to version number (admin footer, CLI, /magento_version, swagger) have to be changed to use `getDistributionVersion()` instead of `getVersion()`.

### Related Pull Requests
* https://github.com/mage-os/generate-mirror-repo-js/pull/189

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format mage-os/mageos-magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes mage-os/mageos-magento2#108

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Build a Mage-OS preview release (currently unable to; see related PR above).
2. Run CLI command `bin/magento --version`; see output like: `Mage-OS CLI 1.0.5 (based on Magento 2.4.7-p3)`
3. Open the admin panel and log in; view the footer. See output like: `Mage-OS ver. 1.0.5`

### Questions or comments

Opening this as a draft PR due to inability to test it end to end, as the build process is currently broken.

Unit/integration tests might be affected and require further attention. I didn't get there yet.

I split `getVersion()`, but not `getName()`, which returns `Mage-OS` rather than `Magento`. Should that be split too?

I created a new interface `DistributionMetadataInterface`, on the thinking that third parties could use that (`instanceof DistributionMetadataInterface`) to help determine whether an install is Mage-OS, and that this would be better for backwards compatibility by not introducing new methods to `ProductMetadataInterface`. Thoughts?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
