### PR TITLE
Solve bug #116 - Setting number of address line lower breaks checkout

### DIFF
--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -17,6 +17,7 @@ use Magento\Customer\Model\Data\Address as AddressData;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Model\AbstractExtensibleModel;
 use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
+use Magento\Customer\Helper\Address as AddressHelper;
 
 /**
  * Address abstract model
@@ -147,6 +148,11 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
     private array $regionIdCountry = [];
 
     /**
+     * @var AddressHelper|null
+     */
+    protected ?AddressHelper $addressHelper;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory
@@ -166,6 +172,7 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
      * @param CompositeValidator $compositeValidator
      * @param CountryModelsCache|null $countryModelsCache
      * @param RegionModelsCache|null $regionModelsCache
+     * @param Magento\Customer\Helper\Address\AddressHelper|null $addressHelper
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -189,6 +196,7 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
         ?CompositeValidator $compositeValidator = null,
         ?CountryModelsCache $countryModelsCache = null,
         ?RegionModelsCache $regionModelsCache = null,
+        ?AddressHelper $addressHelper = null
     ) {
         $this->_directoryData = $directoryData;
         $data = $this->_implodeArrayField($data);
@@ -206,6 +214,8 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
             ->get(CountryModelsCache::class);
         $this->regionModelsCache = $regionModelsCache ?: ObjectManager::getInstance()
             ->get(RegionModelsCache::class);
+        $this->addressHelper = $addressHelper ?: ObjectManager::getInstance()
+            ->get(AddressHelper::class);
         parent::__construct(
             $context,
             $registry,
@@ -242,6 +252,8 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
 
     /**
      * Retrieve street field of an address
+     * Honour current configured street lines, and convert
+     * legacy data to match
      *
      * @return string[]
      */
@@ -250,7 +262,11 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
         if (is_array($this->getStreetFull())) {
             return $this->getStreetFull();
         }
-        return explode("\n", $this->getStreetFull());
+        $maxAllowedLineCount = $this->addressHelper->getStreetLines() ?? 2;
+        $lines = explode("\n", $this->getStreetFull());
+        $lines = $this->addressHelper->convertStreetLines($lines, $maxAllowedLineCount);
+        $this->setStreetFull(implode("\n", $lines));
+        return $lines;
     }
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
@@ -70,6 +70,8 @@ class AbstractAddressTest extends TestCase
     /** @var CompositeValidator|MockObject  */
     private $compositeValidatorMock;
 
+    private $addressHelperMock;
+
     protected function setUp(): void
     {
         $this->contextMock = $this->createMock(Context::class);
@@ -489,6 +491,89 @@ class AbstractAddressTest extends TestCase
                 $model->getCustomAttributes()
             )
         );
+    }
+
+    public function testGetStreetWithTwoLines()
+    {
+        // Create a partial mock for AddressHelper
+        $this->addressHelperMock = $this->getMockBuilder(\Magento\Customer\Helper\Address::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getStreetLines']) // Mock only getStreetLines, keep the real convertStreetLines
+            ->getMock();
+
+        // Mock getStreetLines to return 2 by default
+        $this->addressHelperMock->method('getStreetLines')->willReturn(2);
+
+        // Use reflection to inject the partial mock into the model
+        $reflection = new \ReflectionClass($this->model);
+        $property = $reflection->getProperty('addressHelper');
+        $property->setAccessible(true);
+        $property->setValue($this->model, $this->addressHelperMock);
+
+        $this->addressHelperMock->method('getStreetLines')->willReturn(2);
+        $streetData = ["Street Line 1", "Street Line 2", "Street Line 3", "Street Line 4"];
+        $this->model->setData('street', $streetData);
+
+        // Call getStreet() which should internally call convertStreetLines()
+        $result = $this->model->getStreet();
+
+        // Assert that empty and whitespace-only lines are removed by convertStreetLines
+        $this->assertEquals(["Street Line 1 Street Line 2", "Street Line 3 Street Line 4"], $result);
+    }
+
+    public function testGetStreetWithThreeLines()
+    {
+        // Create a partial mock for AddressHelper
+        $this->addressHelperMock = $this->getMockBuilder(\Magento\Customer\Helper\Address::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getStreetLines']) // Mock only getStreetLines, keep the real convertStreetLines
+            ->getMock();
+
+        // Mock getStreetLines to return 2 by default
+        $this->addressHelperMock->method('getStreetLines')->willReturn(3);
+
+        // Use reflection to inject the partial mock into the model
+        $reflection = new \ReflectionClass($this->model);
+        $property = $reflection->getProperty('addressHelper');
+        $property->setAccessible(true);
+        $property->setValue($this->model, $this->addressHelperMock);
+
+        $this->addressHelperMock->method('getStreetLines')->willReturn(3);
+        $streetData = ["Street Line 1", "Street Line 2", "Street Line 3", "Street Line 4"];
+        $this->model->setData('street', $streetData);
+
+        // Call getStreet() which should internally call convertStreetLines()
+        $result = $this->model->getStreet();
+
+        // Assert that empty and whitespace-only lines are removed by convertStreetLines
+        $this->assertEquals(["Street Line 1 Street Line 2","Street Line 3","Street Line 4"], $result);
+    }
+
+    public function testGetStreetWithOneLine()
+    {
+        // Create a partial mock for AddressHelper
+        $this->addressHelperMock = $this->getMockBuilder(\Magento\Customer\Helper\Address::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getStreetLines']) // Mock only getStreetLines, keep the real convertStreetLines
+            ->getMock();
+
+        // Mock getStreetLines to return 2 by default
+        $this->addressHelperMock->method('getStreetLines')->willReturn(1);
+
+        // Use reflection to inject the partial mock into the model
+        $reflection = new \ReflectionClass($this->model);
+        $property = $reflection->getProperty('addressHelper');
+        $property->setAccessible(true);
+        $property->setValue($this->model, $this->addressHelperMock);
+
+        $streetData = ["Street Line 1", "Street Line 2", "Street Line 3", "Street Line 4"];
+        $this->model->setData('street', $streetData);
+
+        // Call getStreet() which should internally call convertStreetLines()
+        $result = $this->model->getStreet();
+
+        // Assert that empty and whitespace-only lines are removed by convertStreetLines
+        $this->assertEquals(["Street Line 1 Street Line 2 Street Line 3 Street Line 4"], $result);
     }
 
     protected function tearDown(): void

--- a/app/code/Magento/Customer/etc/di.xml
+++ b/app/code/Magento/Customer/etc/di.xml
@@ -593,4 +593,9 @@
                 type="Magento\Customer\Plugin\AsyncRequestCustomerGroupAuthorization"
         />
     </type>
+    <type name="Magento\Customer\Model\Address\AbstractAddress">
+        <arguments>
+            <argument name="addressHelper" xsi:type="object">Magento\Customer\Helper\Address</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
### Description (*)

Refer to bug mage-os/mageos-magento2#116

The code adjusts the fetch of Street lines to ensure result matches expected address lines, if legacy data.
Legacy data with address lines > as current configured will break checkout, as described in detail in bug.
The code uses existing method in core that is meant to do this, but was never actually called.


### Related Pull Requests
N/A

### Fixed Issues (if relevant)

1. Fixes mage-os/mageos-magento2#116

### Manual testing scenarios (*)

The issue is directly related to legacy address data in address fields, after address was limited to lesser address lines.
The first step is to get a longer address saved, and used, then go back, and retry after address lines were changed.
Extensive detailed testing in note din the ticket on how to reproduce.  Refer to bug mage-os/mageos-magento2#116


### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [*] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green) - as noted in ticket, there are unrelated tests that fail out the box on a clean install. Tests related to this change was tested and works.
 
 
![image](https://github.com/user-attachments/assets/96006263-05ed-4465-a7d6-79383fe8a99e)
