### PR TITLE
Cherry-pick: Split Magento and Mage-OS versions in ProductMetadata for compatibility (#115)

### DIFF
--- a/app/code/Magento/Backend/Block/Page/Footer.php
+++ b/app/code/Magento/Backend/Block/Page/Footer.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Backend\Block\Page;
 
+use Magento\Framework\App\DistributionMetadataInterface;
+
 /**
  * Adminhtml footer block
  *
@@ -20,7 +22,7 @@ class Footer extends \Magento\Backend\Block\Template
     protected $_template = 'Magento_Backend::page/footer.phtml';
 
     /**
-     * @var \Magento\Framework\App\ProductMetadataInterface
+     * @var \Magento\Framework\App\ProductMetadataInterface|DistributionMetadataInterface
      * @since 100.1.0
      */
     protected $productMetadata;
@@ -55,7 +57,17 @@ class Footer extends \Magento\Backend\Block\Template
      */
     public function getMagentoVersion()
     {
-        return $this->productMetadata->getVersion();
+        return $this->productMetadata->getDistributionVersion();
+    }
+
+    /**
+     * Get product name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->productMetadata->getDistributionName();
     }
 
     /**

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/footer.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/footer.phtml
@@ -11,6 +11,6 @@ use Magento\Framework\Escaper;
 /** @var Footer $block */
 ?>
 <p class="magento-version">
-    <strong><?= $escaper->escapeHtml(__('Mage-OS')); ?></strong>
+    <strong><?= $escaper->escapeHtml(__($block->getName())); ?></strong>
     <?= $escaper->escapeHtml(__('ver. %1', $block->getMagentoVersion())); ?>
 </p>

--- a/app/code/Magento/Version/Controller/Index/Index.php
+++ b/app/code/Magento/Version/Controller/Index/Index.php
@@ -10,6 +10,7 @@ namespace Magento\Version\Controller\Index;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\DistributionMetadataInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Controller\Result\RawFactory as RawResponseFactory;
 
@@ -21,7 +22,7 @@ class Index extends Action implements HttpGetActionInterface
     public const DEV_PREFIX = 'dev-';
 
     /**
-     * @var ProductMetadataInterface
+     * @var ProductMetadataInterface|DistributionMetadataInterface
      */
     private $productMetadata;
 
@@ -52,11 +53,11 @@ class Index extends Action implements HttpGetActionInterface
     {
         $rawResponse = $this->rawFactory->create();
 
-        $version = $this->productMetadata->getVersion() ?? '';
+        $version = $this->productMetadata->getDistributionVersion() ?? '';
         $versionParts = explode('.', $version);
         if (!$this->isGitBasedInstallation($version) && $this->isCorrectVersion($versionParts)) {
             $rawResponse->setContents(
-                $this->productMetadata->getName() . '/' .
+                $this->productMetadata->getDistributionName() . '/' .
                 $this->getMajorMinorVersion($versionParts) .
                 ' (' . $this->productMetadata->getEdition() . ')'
             );

--- a/app/code/Magento/Version/Test/Unit/Controller/Index/IndexTest.php
+++ b/app/code/Magento/Version/Test/Unit/Controller/Index/IndexTest.php
@@ -41,7 +41,7 @@ class IndexTest extends TestCase
 
         $this->productMetadataMock = $this->getMockBuilder(ProductMetadataInterface::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getName', 'getEdition', 'getVersion'])
+            ->onlyMethods(['getName', 'getEdition', 'getVersion', 'getDistributionName', 'getDistributionVersion'])
             ->getMockForAbstractClass();
 
         $this->rawResponseFactoryMock = $this->createPartialMock(RawFactory::class, ['create']);
@@ -78,9 +78,13 @@ class IndexTest extends TestCase
         $this->productMetadataMock->expects($this->any())->method('getVersion')->willReturn('2.3.3');
         $this->productMetadataMock->expects($this->any())->method('getEdition')->willReturn('Community');
         $this->productMetadataMock->expects($this->any())->method('getName')->willReturn('Magento');
+        $this->productMetadataMock->expects($this->any())->method('getDistributionVersion')
+            ->willReturn('1.1.0');
+        $this->productMetadataMock->expects($this->any())->method('getDistributionName')
+            ->willReturn('Mage-OS');
 
         $this->rawResponseMock->expects($this->once())->method('setContents')
-            ->with('Magento/2.3 (Community)')
+            ->with('Mage-OS/1.1 (Community)')
             ->willReturnSelf();
 
         $this->versionController->execute();

--- a/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
+++ b/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
@@ -6,6 +6,7 @@
 namespace Magento\Webapi\Model\Rest\Swagger;
 
 use Magento\Framework\Api\SimpleDataObjectConverter;
+use Magento\Framework\App\DistributionMetadataInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Reflection\TypeProcessor;
 use Magento\Framework\Webapi\Authorization;
@@ -52,7 +53,7 @@ class Generator extends AbstractSchemaGenerator
     /**
      * Magento product metadata
      *
-     * @var ProductMetadataInterface
+     * @var ProductMetadataInterface|DistributionMetadataInterface
      */
     protected ProductMetadataInterface $productMetadata;
 
@@ -182,7 +183,7 @@ class Generator extends AbstractSchemaGenerator
      */
     protected function getGeneralInfo()
     {
-        $versionParts = explode('.', $this->productMetadata->getVersion());
+        $versionParts = explode('.', $this->productMetadata->getDistributionVersion());
         if (!isset($versionParts[0]) || !isset($versionParts[1])) {
             return []; // Major and minor version are not set - return empty response
         }
@@ -190,7 +191,7 @@ class Generator extends AbstractSchemaGenerator
 
         return [
             'version' => $majorMinorVersion,
-            'title' => $this->productMetadata->getName() . ' ' . $this->productMetadata->getEdition(),
+            'title' => $this->productMetadata->getDistributionName() . ' ' . $this->productMetadata->getEdition(),
         ];
     }
 

--- a/app/code/Magento/Webapi/Test/Unit/Model/Rest/Swagger/GeneratorTest.php
+++ b/app/code/Magento/Webapi/Test/Unit/Model/Rest/Swagger/GeneratorTest.php
@@ -187,7 +187,7 @@ class GeneratorTest extends TestCase
             );
 
         $this->productMetadata->expects($this->once())
-            ->method('getVersion')
+            ->method('getDistributionVersion')
             ->willReturn('UNKNOWN');
 
         $this->assertEquals(

--- a/dev/tests/integration/testsuite/Magento/Version/Controller/Index/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Version/Controller/Index/IndexTest.php
@@ -16,10 +16,10 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractController
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         /** @var \Magento\Framework\App\ProductMetadataInterface $productMetadata */
         $productMetadata = $objectManager->get(\Magento\Framework\App\ProductMetadataInterface::class);
-        $name = $productMetadata->getName();
+        $name = $productMetadata->getDistributionName();
         $edition = $productMetadata->getEdition();
 
-        $fullVersion = $productMetadata->getVersion();
+        $fullVersion = $productMetadata->getDistributionVersion();
         if ($this->isComposerBasedInstallation($fullVersion)) {
             $versionParts = explode('.', $fullVersion);
             $majorMinor = $versionParts[0] . '.' . $versionParts[1];

--- a/lib/internal/Magento/Framework/App/DistributionMetadataInterface.php
+++ b/lib/internal/Magento/Framework/App/DistributionMetadataInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * (c) Mage-OS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * files distributed with this source code.
+ */
+namespace Magento\Framework\App;
+
+/**
+ * Mage-OS Distribution metadata
+ *
+ * @api
+ * @since 1.0.6
+ */
+interface DistributionMetadataInterface
+{
+    /**
+     * Get Distribution version
+     *
+     * @return string
+     */
+    public function getDistributionVersion();
+
+    /**
+     * Get Distribution name
+     *
+     * @return string
+     */
+    public function getDistributionName();
+}

--- a/lib/internal/Magento/Framework/App/ProductMetadata.php
+++ b/lib/internal/Magento/Framework/App/ProductMetadata.php
@@ -15,7 +15,7 @@ use Magento\Framework\Composer\ComposerInformation;
 /**
  * Magento application product metadata
  */
-class ProductMetadata implements ProductMetadataInterface
+class ProductMetadata implements ProductMetadataInterface, DistributionMetadataInterface
 {
     /**
      * Magento product edition
@@ -25,7 +25,12 @@ class ProductMetadata implements ProductMetadataInterface
     /**
      * Magento product name
      */
-    const PRODUCT_NAME  = 'Mage-OS';
+    public const PRODUCT_NAME  = 'Magento';
+
+    /**
+     * Distribution product name
+     */
+    public const DISTRIBUTION_NAME  = 'Mage-OS';
 
     /**
      * Magento version cache key
@@ -33,11 +38,23 @@ class ProductMetadata implements ProductMetadataInterface
     const VERSION_CACHE_KEY = 'mage-version';
 
     /**
+     * Distribution version cache key
+     */
+    protected const DISTRO_VERSION_CACHE_KEY = 'distro-version';
+
+    /**
      * Product version
      *
      * @var string
      */
     protected $version;
+
+    /**
+     * Distribution version
+     *
+     * @var string
+     */
+    protected $distroVersion;
 
     /**
      * @var \Magento\Framework\Composer\ComposerJsonFinder
@@ -90,6 +107,27 @@ class ProductMetadata implements ProductMetadataInterface
     }
 
     /**
+     * Get Distribution version
+     *
+     * @return string
+     */
+    public function getDistributionVersion()
+    {
+        $this->distroVersion = $this->distroVersion ?: $this->cache->load(self::DISTRO_VERSION_CACHE_KEY);
+        if (!$this->distroVersion) {
+            if (!($this->distroVersion = $this->getSystemDistroVersion())) {
+                if ($this->getComposerInformation()->isMagentoRoot()) {
+                    $this->distroVersion = $this->getComposerInformation()->getRootPackage()->getPrettyVersion();
+                } else {
+                    $this->distroVersion = 'UNKNOWN';
+                }
+            }
+            $this->cache->save($this->distroVersion, self::DISTRO_VERSION_CACHE_KEY, [Config::CACHE_TAG]);
+        }
+        return $this->distroVersion;
+    }
+
+    /**
      * Get Product edition
      *
      * @return string
@@ -110,12 +148,38 @@ class ProductMetadata implements ProductMetadataInterface
     }
 
     /**
+     * Get Distribution name
+     *
+     * @return string
+     */
+    public function getDistributionName()
+    {
+        return self::DISTRIBUTION_NAME;
+    }
+
+    /**
      * Get version from system package
      *
      * @return string
      * @deprecated 100.1.0
      */
     private function getSystemPackageVersion()
+    {
+        $packages = $this->getComposerInformation()->getSystemPackages();
+        foreach ($packages as $package) {
+            if (isset($package['name']) && isset($package['magento_version'])) {
+                return $package['magento_version'];
+            }
+        }
+        return '';
+    }
+
+    /**
+     * Get distribution version from system package
+     *
+     * @return string
+     */
+    private function getSystemDistroVersion()
     {
         $packages = $this->getComposerInformation()->getSystemPackages();
         foreach ($packages as $package) {

--- a/lib/internal/Magento/Framework/Composer/ComposerInformation.php
+++ b/lib/internal/Magento/Framework/Composer/ComposerInformation.php
@@ -246,7 +246,8 @@ class ComposerInformation
                 $packages[$package->getName()] = [
                     'name' => $package->getName(),
                     'type' => $package->getType(),
-                    'version' => $package->getPrettyVersion()
+                    'version' => $package->getPrettyVersion(),
+                    'magento_version' => $package->getExtra()['magento_version'] ?? null,
                 ];
             }
         }

--- a/setup/index.php
+++ b/setup/index.php
@@ -41,7 +41,7 @@ $metaClass = $objectManager->create(ProductMetadata::class);
 /** @var License $license */
 $license = $licenseClass->getContents();
 /** @var ProductMetadata $version */
-$version = $metaClass->getVersion();
+$version = $metaClass->getDistributionVersion();
 
 $request = new Request();
 $basePath = $request->getBasePath();


### PR DESCRIPTION
This copies https://github.com/mage-os/mageos-magento2/pull/115 from release/1.x to 2.4-develop for future releases.