### PR TITLE
feat!: prevent catalog and sales rules from being disclosed publicly …

### DIFF
--- a/app/code/Magento/CatalogRule/etc/config.xml
+++ b/app/code/Magento/CatalogRule/etc/config.xml
@@ -9,7 +9,7 @@
     <default>
         <catalog>
             <rule>
-                <share_all_catalog_rules>1</share_all_catalog_rules>
+                <share_all_catalog_rules>0</share_all_catalog_rules>
                 <share_applied_catalog_rules>1</share_applied_catalog_rules>
             </rule>
         </catalog>

--- a/app/code/Magento/SalesRule/etc/config.xml
+++ b/app/code/Magento/SalesRule/etc/config.xml
@@ -14,7 +14,7 @@
                 <format>1</format>
             </auto_generated_coupon_codes>
             <graphql>
-                <share_all_sales_rule>1</share_all_sales_rule>
+                <share_all_sales_rule>0</share_all_sales_rule>
                 <share_applied_sales_rule>1</share_applied_sales_rule>
             </graphql>
         </promo>


### PR DESCRIPTION
…by default

### Description (*)

In https://github.com/magento/magento2/commit/efcc63bdbff4e87639db75c8c3011f1b25cf5706 and https://github.com/magento/magento2/commit/a2689a05f4152125ef8adb9184e80f074989b5a3 upstream introduced an unexpected information disclosure. These commits allow anonymous actors to call the graphql api and retrieve the list of all active discounts on the store.

```bash
curl --location 'https://www.yourmagentostore.com/graphql' \
--header 'Content-Type: application/json' \
--data '{"query":"query {\n    allCartRules {\n        name\n    }\n}","variables":{}}'
```

### Manual testing scenarios (*)
1. Run the above cURL command and see `Sharing Cart Rules information is disabled or not configured.`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
