### PR TITLE
feat!: prevent disclosure of customer groups by default

### DIFF
--- a/app/code/Magento/Customer/etc/config.xml
+++ b/app/code/Magento/Customer/etc/config.xml
@@ -33,8 +33,8 @@
                 <change_email_template>customer_account_information_change_email_template</change_email_template>
                 <change_email_and_password_template>customer_account_information_change_email_and_password_template</change_email_and_password_template>
                 <confirm>0</confirm>
-                <graphql_share_all_customer_groups>1</graphql_share_all_customer_groups>
-                <graphql_share_customer_group>1</graphql_share_customer_group>
+                <graphql_share_all_customer_groups>0</graphql_share_all_customer_groups>
+                <graphql_share_customer_group>0</graphql_share_customer_group>
             </account_information>
             <password>
                 <forgot_email_identity>support</forgot_email_identity>


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Historically, in Magento 1 and Magento 2, customer group was a private property only available to administrators, it wasn't publicly shown to customers. 

### Related Pull Requests
@hostep pointed out in #135 that this was an issue.

### Manual Testing Scenarios

#### Before PR
1. Create MageOS 2.4-develop store.
2. Query GraphQL like:

```bash
curl --location 'yourmagentostore/graphql' \
--header 'Content-Type: application/json' \
--data '{"query":"query {\n    allCustomerGroups {\n        name\n    }\n}","variables":{}}'
```

3. Get result.

```json
{
    "data": {
        "allCustomerGroups": [
            {
                "name": "NOT LOGGED IN"
            },
            {
                "name": "General"
            },
            {
                "name": "Wholesale"
            },
            {
                "name": "Retailer"
            }
        ]
    }
}
```


##### After these changes:

```bash
curl --location 'yourmagentostore/graphql' \
--header 'Content-Type: application/json' \
--data '{"query":"query {\n    allCustomerGroups {\n        name\n    }\n}","variables":{}}'
```

```json
{
    "errors": [
        {
            "message": "Sharing customer group information is disabled or not configured.",
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ],
            "path": [
                "allCustomerGroups"
            ],
            "extensions": {
                "category": "graphql-input"
            }
        }
    ],
    "data": {
        "allCustomerGroups": null
    }
}
```

This can also be done via:

```bash
bin/magento config:set customer/account_information/graphql_share_all_customer_groups 0
```

Additionally, this also impacts the `group` node of the `Customer` type in GraphQl.

##### Before

1. Create MageOS 2.4-develop store.
2. Create a user account.
3. Login with GraphQl
4. Use that token to query your account information.
5. Query GraphQL like:

```bash
curl --location 'https://app.exampleproject.test:59128/graphql' \
--header 'Content-Type: application/json' \
--data '{"query":"query {\n    customer {\n        group {\n            name\n        }\n    }\n}","variables":{}}'```
```

Get result:


```json
{
    "data": {
        "customer": {
             "group":  { 
                  "name": "General"
              }
        }
    }
}
```

##### After

```bash
curl --location 'https://app.exampleproject.test:59128/graphql' \
--header 'Content-Type: application/json' \
--data '{"query":"query {\n    customer {\n        group {\n            name\n        }\n    }\n}","variables":{}}'```
```

Get result:


```json
{
    "data": {
        "customer": {
             "group":  null
        }
    }
}
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
 

