### PR TITLE
Performance improvement when applying a coupon code

### DIFF
--- a/app/code/Magento/SalesRule/etc/db_schema.xml
+++ b/app/code/Magento/SalesRule/etc/db_schema.xml
@@ -91,6 +91,9 @@
         <index referenceId="SALESRULE_COUPON_RULE_ID" indexType="btree">
             <column name="rule_id"/>
         </index>
+        <index referenceId="SALESRULE_COUPON_CODE" indexType="btree">
+            <column name="code"/>
+        </index>
     </table>
     <table name="salesrule_coupon_usage" resource="default" engine="innodb" comment="Salesrule Coupon Usage">
         <column xsi:type="int" name="coupon_id" unsigned="true" nullable="false" identity="false"

--- a/app/code/Magento/SalesRule/etc/db_schema_whitelist.json
+++ b/app/code/Magento/SalesRule/etc/db_schema_whitelist.json
@@ -46,7 +46,8 @@
             "type": true
         },
         "index": {
-            "SALESRULE_COUPON_RULE_ID": true
+            "SALESRULE_COUPON_RULE_ID": true,
+            "SALESRULE_COUPON_CODE": true
         },
         "constraint": {
             "PRIMARY": true,


### PR DESCRIPTION
### Description (*)
Adding an index on the code field allows to significantly increase performance and reduce execution time. In the test environment, the execution time of MySQL queries when processing the request to Magento\Checkout\Controller\Cart\CouponPost was reduced from 1.44 s to 131 ms

### Manual testing scenarios (*)
1. Go to the cart and apply the coupon code

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All automated tests passed successfully (all builds are green)
