### PR TITLE
Fix city name validation to allow digits, &, ., () characters

### DIFF
--- a/app/code/Magento/Customer/Model/Validator/City.php
+++ b/app/code/Magento/Customer/Model/Validator/City.php
@@ -20,10 +20,17 @@ class City extends AbstractValidator
      *
      * \p{L}: Unicode letters.
      * \p{M}: Unicode marks (diacritic marks, accents, etc.).
-     * ': Apostrophe mark.
+     * \d: Digits (0-9).
      * \s: Whitespace characters (spaces, tabs, newlines, etc.).
+     * -: Hyphen.
+     * _: Underscore.
+     * ', ’: Apostrophes (straight and typographical).
+     * .: Period/full stop.
+     * ,: Comma.
+     * &: Ampersand.
+     * (): Parentheses.
      */
-    private const PATTERN_CITY = '/(?:[\p{L}\p{M}\s\-\']{1,100})/u';
+    private const PATTERN_CITY = '/^[\p{L}\p{M}\d\s\-_\'’\.,&\(\)]{1,100}$/u';
 
     /**
      * Validate city fields.
@@ -35,7 +42,7 @@ class City extends AbstractValidator
     {
         if (!$this->isValidCity($customer->getCity())) {
             parent::_addMessages([[
-                'city' => "Invalid City. Please use A-Z, a-z, 0-9, -, ', spaces"
+                'city' => "Invalid City. Please use letters, numbers, spaces, and the following characters: - _ ' ’ . , & ( )"
             ]]);
         }
 

--- a/app/code/Magento/Customer/Test/Unit/Model/Validator/CityTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Validator/CityTest.php
@@ -79,6 +79,38 @@ class CityTest extends TestCase
             [
                 'city' => ' Moscow Moscow',
                 'message' => 'Whitespace characters must be allowed in city'
+            ],
+            [
+                'city' => 'O\'Higgins',
+                'message' => 'Straight apostrophe must be allowed in city names'
+            ],
+            [
+                'city' => 'O’Higgins',
+                'message' => 'Typographical apostrophe must be allowed in city names'
+            ],
+            [
+                'city' => 'Saint_Petersburg',
+                'message' => 'Underscore must be allowed in city names'
+            ],
+            [
+                'city' => 'Stratford-upon-Avon',
+                'message' => 'Hyphens must be allowed in city names'
+            ],
+            [
+                'city' => 'St. Petersburg',
+                'message' => 'Periods must be allowed in city names'
+            ],
+            [
+                'city' => 'Trinidad & Tobago',
+                'message' => 'Ampersand must be allowed in city names'
+            ],
+            [
+                'city' => 'Winston-Salem (NC)',
+                'message' => 'Parentheses must be allowed in city names'
+            ],
+            [
+                'city' => 'Rostov-on-Don, Russia',
+                'message' => 'Commas must be allowed in city names'
             ]
         ];
     }


### PR DESCRIPTION
This PR brings https://github.com/magento/magento2/pull/39859 by @bhushan-cs into Mage-OS 2.4-develop branch, it will have to be cherry picked to release/1.x later