### PR TITLE
Fixed missing screen-l styles added using .media-width mixin (magento/magento2#39871)

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping.less
@@ -32,7 +32,7 @@
 @checkout-shipping-item-mobile__active__padding: 15px (@indent__l + 5px) 15px 18px;
 
 @checkout-shipping-item-before__border-color: @color-gray80;
-@checkout-shipping-item-before__height: calc(~'100% - 20px');
+@checkout-shipping-item-before__height: ~"calc(100% - 20px)";
 
 @checkout-shipping-method__border: @checkout-step-title__border;
 @checkout-shipping-method__padding: @indent__base;

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_shipping.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_shipping.less
@@ -32,7 +32,7 @@
 @checkout-shipping-item-mobile__active__padding: 15px (@indent__l + 5px) 15px 18px;
 
 @checkout-shipping-item-before__border-color: @color-gray80;
-@checkout-shipping-item-before__height: calc(~'100% - 20px');
+@checkout-shipping-item-before__height: ~"calc(100% - 20px)";
 
 @checkout-shipping-method__border: @checkout-step-title__border;
 @checkout-shipping-method__padding: @indent__base;

--- a/lib/web/css/source/lib/_responsive.less
+++ b/lib/web/css/source/lib/_responsive.less
@@ -74,6 +74,11 @@
         .media-width('max', @screen__l);
     }
 
+    @media all and (min-width: (@screen__l)),
+    print {
+        .media-width('min', @screen__l);
+    }
+
     @media all and (min-width: @screen__xl),
     print {
         .media-width('min', @screen__xl);


### PR DESCRIPTION
The original commit was a merge, so I used `git cherry-pick -m 1 61cab4b` to bring it here