### PR TITLE
Fix PHP 8.4 Deprecation: Explicitly Mark Nullable Parameter in CanViewNotification

### DIFF
--- a/app/code/Magento/AdminAnalytics/Model/Condition/CanViewNotification.php
+++ b/app/code/Magento/AdminAnalytics/Model/Condition/CanViewNotification.php
@@ -55,7 +55,7 @@ class CanViewNotification implements VisibilityConditionInterface
     public function __construct(
         Logger $viewerLogger,
         CacheInterface $cacheStorage,
-        ScopeConfigInterface $scopeConfig = null
+        ?ScopeConfigInterface $scopeConfig = null
     ) {
         $this->viewerLogger = $viewerLogger;
         $this->cacheStorage = $cacheStorage;


### PR DESCRIPTION
### Description (*)
This pull request updates the constructor of the CanViewNotification class to explicitly declare the nullable parameter $scopeConfig as ?ScopeConfigInterface. This change resolves the PHP 8.4 deprecation warning regarding implicitly nullable parameters.

<img width="1881" height="193" alt="image" src="https://github.com/user-attachments/assets/44f18b63-7538-4238-a1aa-e31931a46f9d" />


### Related Pull Requests


### Fixed Issues (if relevant)


### Manual testing scenarios (*)
Tested on PHP 8.4 to confirm that the deprecation warning is resolved and that the application behaves as expected:
 - Run bin/magento setup:di:compile and ensure no PHP 8.4 deprecation warnings appear.
 - Verify that the admin panel and frontend load correctly without errors.

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
