### PR TITLE
Fix admin dashboard JS error on login

### DIFF
--- a/app/code/Magento/AdminAnalytics/view/adminhtml/layout/adminhtml_dashboard_index.xml
+++ b/app/code/Magento/AdminAnalytics/view/adminhtml/layout/adminhtml_dashboard_index.xml
@@ -15,7 +15,7 @@
             <block name="tracking_notification"
                    as="tracking_notification"
                    template="Magento_AdminAnalytics::notification.phtml"
-                   ifconfig="admin/usage/enabled">
+            >
                 <arguments>
                     <argument name="notification" xsi:type="object">Magento\AdminAnalytics\ViewModel\Notification</argument>
                 </arguments>


### PR DESCRIPTION
### Description (*)

The dashboard can have a JS error on login if admin analytics are disabled, because there's a dependent JS module declaration that never gets output. This happens because of a layout config check that was added in #45 but isn't necessary.

### Related Pull Requests
#45

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
1. Log into the admin panel
2. Observe that it works

### Questions or comments
\-

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
