### PR TITLE
Check if array element exists  in config load

### DIFF
--- a/app/code/Magento/Config/Model/Config/Structure/Element/Iterator.php
+++ b/app/code/Magento/Config/Model/Config/Structure/Element/Iterator.php
@@ -60,7 +60,13 @@ class Iterator implements \Iterator
         $this->_scope = $scope;
         if (count($elements)) {
             $lastElement = end($elements);
-            $this->_lastId = $lastElement['id'];
+            if (isset($lastElement['id'])) {
+                $this->_lastId = $lastElement['id'];
+            } else {
+                throw new \InvalidArgumentException(
+                    'Missing id key in config structure element. LastElement: ' . json_encode($lastElement)
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Description (*)
the core code assumes the 'id' element exists, and if not causes a hard fail, with no information to help debug the issue, which is especially frustrating if issue only appears on a production server.

The issue causes a hard fail, and will result in admin config section being broken.
The resulting error information is not helpful, especially if the issue only appears on a remote production server

```{"0":"Warning: Undefined array key \"id\" in \/data\/web\/deployments\/a769d743e06e2e725dbad93f75570a5744504dd8_29\/vendor\/mage-os\/module-config\/Model\/Config\/Structure\/Element\/Iterator.php on line 63","1":"#1 Magento\\Config\\Model\\Config\\Structure\\Element\\Iterator->setElements() called at [vendor\/mage-os\/module-config\/Model\/Config\/Structure.php:146]\n#2 Magento\\Config\\Model\\Config\\Structure->getTabs() called at [vendor\/mage-os\/module-config\/Model\/Config\/Structure.php:211]\n#3 Magento\\Config\\Model\\Config\\Structure->getFirstSection() called at [vendor\/mage-os\/module-config\/Controller\/Adminhtml\/System\/AbstractConfig.php:63]\n#4 Magento\\Config\\Controller\\Adminhtml\\System\\AbstractConfig->dispatch() called at [generated\/code\/Magento\/Config\/Controller\/Adminhtml\/System\/Config\/Index\/Interceptor.php:176]\n#5 Magento\\Config\\Controller\\Adminhtml\\System\\Config\\Index\\Interceptor->Magento\\Config\\Controller\\Adminhtml\\System\\Config\\Index\\{closure}() called at [vendor\/mage-os\/module-backend\/App\/Action\/Plugin\/Authentication.php:145]\n#6 Magento\\Backend\\App\\Action\\Plugin\\Authentication->aroundDispatch() called at [generated\/code\/Magento\/Config\/Controller\/Adminhtml\/System\/Config\/Index\/Interceptor.php:171]\n#7 Magento\\Config\\Controller\\Adminhtml\\System\\Config\\Index\\Interceptor->dispatch() called at [vendor\/mage-os\/framework\/App\/FrontController.php:245]\n#8 Magento\\Framework\\App\\FrontController->getActionResponse() called at [vendor\/mage-os\/framework\/App\/FrontController.php:212]\n#9 Magento\\Framework\\App\\FrontController->processRequest() called at [vendor\/mage-os\/framework\/App\/FrontController.php:146]\n#10 Magento\\Framework\\App\\FrontController->dispatch() called at [generated\/code\/Magento\/Framework\/App\/FrontController\/Interceptor.php:102]\n#11 Magento\\Framework\\App\\FrontController\\Interceptor->dispatch() called at [vendor\/mage-os\/framework\/App\/Http.php:116]\n#12 Magento\\Framework\\App\\Http->launch() called at [generated\/code\/Magento\/Framework\/App\/Http\/Interceptor.php:50]\n#13 Magento\\Framework\\App\\Http\\Interceptor->Magento\\Framework\\App\\Http\\{closure}() called at [vendor\/mage-os\/module-application-performance-monitor\/Plugin\/ApplicationPerformanceMonitor.php:43]\n#14 Magento\\ApplicationPerformanceMonitor\\Plugin\\ApplicationPerformanceMonitor->Magento\\ApplicationPerformanceMonitor\\Plugin\\{closure}() called at [vendor\/mage-os\/module-application-performance-monitor\/Profiler\/Profiler.php:59]\n#15 Magento\\ApplicationPerformanceMonitor\\Profiler\\Profiler->doProfile() called at [vendor\/mage-os\/module-application-performance-monitor\/Plugin\/ApplicationPerformanceMonitor.php:41]\n#16 Magento\\ApplicationPerformanceMonitor\\Plugin\\ApplicationPerformanceMonitor->aroundLaunch() called at [generated\/code\/Magento\/Framework\/App\/Http\/Interceptor.php:48]\n#17 Magento\\Framework\\App\\Http\\Interceptor->launch() called at [vendor\/mage-os\/framework\/App\/Bootstrap.php:264]\n#18 Magento\\Framework\\App\\Bootstrap->run() called at [pub\/index.php:30]\n","url":"\/admin-uptactics\/admin\/system_config\/index\/key\/b9047e4f1dc769fd7262ec670d8070fab118e260211b8076e321e5345d8d3da0\/","script_name":"\/index.php","report_id":"b58f50a8853cadb32577c03b8e0eca008ee4702a9de80d9d01f00a7bac4985de"```

The proposed change will trap this occurrence, and log a more meaningful error/information: (full error not shown as not all relevant needed for this ticket)

```[2025-10-09T01:05:48.209305+00:00] main.ERROR: Missing id key in config structure element. LastElement: {"children":{"amasty_report_builder":{"id":"amasty_report_builder","translate":"label","type":"text","sortOrder":"031802","showInDefault":"1","showInWebsite":"1","showInStore":"1","resource":"Amasty_ReportBuilder::config","class":"separator-top","label":"Custom Reports Builder","tab":"amasty","children":{"amasty_information":{"id":"amasty_information",```

Now, in this instance, armed with better logging, I can see issue is triggered by an amasty module having child elements, rather than a direct occurrence of 'id'. Why I don;t know yet, and is not in scope of this ticket, which is to facilitate better logging.


This is extremely edge case:

The amasty module has a base module: Amasty_Base
It was being disabled/was disabled on this specific instance, via a custom config.php on that server.
So, since two other amasty modules were enabled, but the base was disabled, it skewed the config array, thus eliminating the top level config array details, as what is held in Amasty_Base

Th end result is an array with just the child elements (modules) but no actual 'id' key for own details (as it was disabled)
