### PR TITLE
Added missing composer file for Magento/Framework/Stomp

### DIFF
--- a/lib/internal/Magento/Framework/Stomp/composer.json
+++ b/lib/internal/Magento/Framework/Stomp/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "magento/framework-stomp",
+    "description": "N/A",
+    "config": {
+        "sort-packages": true
+    },
+    "type": "magento2-library",
+    "license": [
+        "OSL-3.0",
+        "AFL-3.0"
+    ],
+    "require": {
+        "magento/framework": "*",
+        "php": "~8.2.0||~8.3.0||~8.4.0",
+        "stomp-php/stomp-php": "^5.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Magento\\Framework\\Stomp\\": ""
+        },
+        "files": [
+            "registration.php"
+        ]
+    }
+}


### PR DESCRIPTION
I skipped composer.json files in #171 but we do need this specific one (in a dev version, other than what was released).

Fixes build error: https://github.com/mage-os/generate-mirror-repo-js/actions/runs/18514612643/job/52762454141

```
Error: Error: generate-repo/repositories/mageos-magento2/app/code/Magento/Stomp doesn't contain a composer.json! Please add to excludes in config.
```