### PR TITLE
chore: Remove outdated `replace` and `extra` definitions from composer files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -339,33 +339,11 @@
         "magento/framework-amqp": "*",
         "magento/framework-bulk": "*",
         "magento/framework-message-queue": "*",
-        "trentrichardson/jquery-timepicker-addon": "1.4.3",
-        "components/jquery": "1.11.0",
-        "components/jqueryui": "1.10.4",
-        "twbs/bootstrap": "3.1.0",
         "magento/module-csp": "*",
         "magento/module-aws-s3": "*",
         "magento/module-remote-storage": "*",
         "magento/module-jwt-framework-adapter": "*",
         "magento/module-jwt-user-token": "*"
-    },
-    "conflict": {
-        "gene/bluefoot": "*"
-    },
-    "extra": {
-        "component_paths": {
-            "trentrichardson/jquery-timepicker-addon": "lib/web/jquery/jquery-ui-timepicker-addon.js",
-            "components/jquery": [
-                "lib/web/jquery.js",
-                "lib/web/jquery/jquery.min.js"
-            ],
-            "components/jqueryui": [
-                "lib/web/jquery/jquery-ui.js"
-            ],
-            "twbs/bootstrap": [
-                "lib/web/jquery/jquery.tabs.js"
-            ]
-        }
     },
     "autoload": {
         "psr-4": {

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/composer.json
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/composer.json
@@ -153,33 +153,13 @@
         "magento/language-pt_br": "*",
         "magento/language-zh_cn": "*",
         "magento/framework": "*",
-        "trentrichardson/jquery-timepicker-addon": "1.4.3",
         "colinmollenhour/cache-backend-redis": "dev-master#193d377b7fb2e88595578b282fa01a62d1185abc",
-        "colinmollenhour/credis": "dev-master#f07bbfd4117294f462f0fb19c49221d350bf396f",
-        "linkorb/jsmin-php": "1.1.2",
-        "components/jquery": "1.11.0",
-        "blueimp/jquery-file-upload": "5.6.14",
-        "components/jqueryui": "1.10.4",
-        "twbs/bootstrap": "3.1.0"
+        "colinmollenhour/credis": "dev-master#f07bbfd4117294f462f0fb19c49221d350bf396f"
     },
     "extra": {
         "component_paths": {
-            "trentrichardson/jquery-timepicker-addon": "lib/web/jquery/jquery-ui-timepicker-addon.js",
             "colinmollenhour/cache-backend-redis": "lib/internal/Cm/Cache/Backend/Redis.php",
-            "colinmollenhour/credis": "lib/internal/Credis",
-            "linkorb/jsmin-php": "lib/internal/JSMin",
-            "components/jquery": [
-                "lib/web/jquery.js",
-                "lib/web/jquery/jquery.min.js"
-            ],
-            "blueimp/jquery-file-upload": "lib/web/jquery/fileUploader",
-            "components/jqueryui": [
-                "lib/web/jquery/jquery-ui.js",
-                "lib/web/jquery/jquery-ui.min.js"
-            ],
-            "twbs/bootstrap": [
-                "lib/web/jquery/jquery.tabs.js"
-            ]
+            "colinmollenhour/credis": "lib/internal/Credis"
         }
     },
     "config": {

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/composer.lock
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/composer.lock
@@ -2310,28 +2310,8 @@
                 "laminas/laminas-validator": "^2.6.0",
                 "laminas/laminas-view": "~2.10.0"
             },
-            "conflict": {
-                "gene/bluefoot": "*"
-            },
-            "replace": {
-                "blueimp/jquery-file-upload": "5.6.14",
-                "components/jquery": "1.11.0",
-                "components/jqueryui": "1.10.4",
-                "trentrichardson/jquery-timepicker-addon": "1.4.3",
-                "twbs/bootstrap": "3.1.0"
-            },
             "type": "magento2-component",
             "extra": {
-                "component_paths": {
-                    "trentrichardson/jquery-timepicker-addon": "lib/web/jquery/jquery-ui-timepicker-addon.js",
-                    "components/jquery": [
-                        "lib/web/jquery.js",
-                        "lib/web/jquery/jquery.min.js"
-                    ],
-                    "blueimp/jquery-file-upload": "lib/web/jquery/fileUploader",
-                    "components/jqueryui": "lib/web/jquery/jquery-ui.js",
-                    "twbs/bootstrap": "lib/web/jquery/jquery.tabs.js"
-                },
                 "map": [
                     [
                         ".github",

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/composer.lock
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/composer.lock
@@ -2310,28 +2310,8 @@
                 "laminas/laminas-validator": "^2.6.0",
                 "laminas/laminas-view": "~2.10.0"
             },
-            "conflict": {
-                "gene/bluefoot": "*"
-            },
-            "replace": {
-                "blueimp/jquery-file-upload": "5.6.14",
-                "components/jquery": "1.11.0",
-                "components/jqueryui": "1.10.4",
-                "trentrichardson/jquery-timepicker-addon": "1.4.3",
-                "twbs/bootstrap": "3.1.0"
-            },
             "type": "magento2-component",
             "extra": {
-                "component_paths": {
-                    "trentrichardson/jquery-timepicker-addon": "lib/web/jquery/jquery-ui-timepicker-addon.js",
-                    "components/jquery": [
-                        "lib/web/jquery.js",
-                        "lib/web/jquery/jquery.min.js"
-                    ],
-                    "blueimp/jquery-file-upload": "lib/web/jquery/fileUploader",
-                    "components/jqueryui": "lib/web/jquery/jquery-ui.js",
-                    "twbs/bootstrap": "lib/web/jquery/jquery.tabs.js"
-                },
                 "map": [
                     [
                         ".github",

--- a/dev/tests/integration/testsuite/Magento/Setup/Model/_files/testSkeleton/composer.lock
+++ b/dev/tests/integration/testsuite/Magento/Setup/Model/_files/testSkeleton/composer.lock
@@ -461,36 +461,14 @@
                 "magento/magento-composer-installer": "*"
             },
             "replace": {
-                "blueimp/jquery-file-upload": "5.6.14",
                 "colinmollenhour/cache-backend-redis": "dev-master#193d377b7fb2e88595578b282fa01a62d1185abc",
-                "colinmollenhour/credis": "dev-master#f07bbfd4117294f462f0fb19c49221d350bf396f",
-                "components/jquery": "1.11.0",
-                "components/jqueryui": "1.10.4",
-                "linkorb/jsmin-php": "1.1.2",
-                "trentrichardson/jquery-timepicker-addon": "1.4.3",
-                "twbs/bootstrap": "3.1.0"
+                "colinmollenhour/credis": "dev-master#f07bbfd4117294f462f0fb19c49221d350bf396f"
             },
             "type": "magento2-component",
             "extra": {
                 "component_paths": {
-                    "trentrichardson/jquery-timepicker-addon": "lib/web/jquery/jquery-ui-timepicker-addon.js",
                     "colinmollenhour/cache-backend-redis": "lib/internal/Cm/Cache/Backend/Redis.php",
-                    "colinmollenhour/credis": "lib/internal/Credis",
-                    "linkorb/jsmin-php": "lib/internal/JSMin",
-                    "components/jquery": [
-                        "lib/web/jquery.js",
-                        "lib/web/jquery/jquery.min.js",
-                        "lib/web/jquery/jquery-migrate.js",
-                        "lib/web/jquery/jquery-migrate.min.js"
-                    ],
-                    "blueimp/jquery-file-upload": "lib/web/jquery/fileUploader",
-                    "components/jqueryui": [
-                        "lib/web/jquery/jquery-ui.js",
-                        "lib/web/jquery/jquery-ui.min.js"
-                    ],
-                    "twbs/bootstrap": [
-                        "lib/web/jquery/jquery.tabs.js"
-                    ]
+                    "colinmollenhour/credis": "lib/internal/Credis"
                 },
                 "map": [
                     [

--- a/lib/internal/Magento/Framework/App/Test/Unit/_files/test.composer.json
+++ b/lib/internal/Magento/Framework/App/Test/Unit/_files/test.composer.json
@@ -23,22 +23,6 @@
     "replace": {
         "magento/module-marketplace": "100.0.2"
     },
-    "extra": {
-        "component_paths": {
-            "trentrichardson/jquery-timepicker-addon": "lib/web/jquery/jquery-ui-timepicker-addon.js",
-            "components/jquery": [
-                "lib/web/jquery.js",
-                "lib/web/jquery/jquery.min.js",
-            ],
-            "blueimp/jquery-file-upload": "lib/web/jquery/fileUploader",
-            "components/jqueryui": [
-                "lib/web/jquery/jquery-ui.js"
-            ],
-            "twbs/bootstrap": [
-                "lib/web/jquery/jquery.tabs.js"
-            ]
-        }
-    },
     "config": {
         "use-include-path": true
     },


### PR DESCRIPTION
Based on the discussions in https://github.com/magento/magento2/pull/36543 and https://github.com/magento/magento2/issues/34562, this removes all composer `replace` and `extra` references to these packages:

```json
        "blueimp/jquery-file-upload": "5.6.14",
        "components/jquery": "1.11.0",
        "components/jqueryui": "1.10.4",
        "linkorb/jsmin-php": "1.1.2",
        "trentrichardson/jquery-timepicker-addon": "1.4.3",
        "twbs/bootstrap": "3.1.0"
```

These modules all are (or were at some time in the past) integrated into the Magento 2 core codebase. These rules were added to prevent the (mostly JS/frontend) components from being included separately, which would result in duplicate code in an installation.

However:

1. Any such code duplication is a customization issue, and not our responsibility to constrain.
2. Being mostly frontend components, using composer to include them in the first place would be an unusual practice.
3. The mere inclusion of these replace rules is enough to trigger `roave/security-advisories` alerts, which is now audited by default as of Composer 2.9. (See #178)

Removing all references in this way should fix the audit error for Composer 2.9, and clean up in the process.

Tangentially related PR: https://github.com/mage-os/mageos-magento2-page-builder/pull/9