### PR TITLE
Expand allowed versions of MySQL/MariaDB

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1881,7 +1881,7 @@
                 <item name="MariaDB-(10.2-10.6)" xsi:type="string">^10\.[2-6]\.</item>
                 <item name="MariaDB-11.4" xsi:type="string">^11\.4\.</item>
                 <!-- Mage-OS wider compatibility rules to match reessolutions/db-override -->
-                <item name="MySQL-(8.0-8.1)" xsi:type="string">^8\.[0-1]\.</item>
+                <item name="MySQL-(8.0-8.4)" xsi:type="string">^8\.[0-4]\.</item>
                 <item name="MariaDB-(10.2-10.11)" xsi:type="string">^10\.([2-9]|10|11)\.</item>
                 <item name="MariaDB-11.x" xsi:type="string">^11\.</item>
             </argument>


### PR DESCRIPTION
<!---
    Thank you for contributing to Mage-OS.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This integrates the idea and work of https://github.com/Sental/db-override into the Mage-OS core.

Currently if you try to install Mage-OS on, say, MariaDB 10.11, you'll get an error. It's perfectly compatible, but Magento errs on the side of caution and only allows installation with specific known supported versions/DB engines: MySQL 5.7, 8.0; MariaDB 10.4, 10.5, 10.6, 11.4.

This expands the supported versions to include MySQL 8.1, and all MariaDB 10.2-10.11 and 11.x.

I added the new rules separately so that they shouldn't cause merge conflicts with changes to Magento's supported DB rules upstream.

### Related Pull Requests
\-

### Fixed Issues (if relevant)
\-

### Manual testing scenarios (*)
1. Install MariaDB 10.11.
2. Run `setup:install`, without the patch. Get error.
3. Run `setup:install`, with the patch. Install successfully.

### Questions or comments
The unit test for the related class is unaffected, still runs cleanly.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
