### PR TITLE
Cherry-pick: fixing setup:di:compile area order in plugin generation …

### DIFF
--- a/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
+++ b/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
@@ -217,7 +217,10 @@ class PluginList extends Scoped implements InterceptionPluginList
             }
             $this->_scopePriorityScheme[] = $scope;
 
-            $cacheId = implode('|', $this->_scopePriorityScheme) . "|" . $this->_cacheId;
+            // Normalize cache ID by sorting scopes - ensures consistent ID regardless of processing order
+            $sortedScheme = array_values($this->_scopePriorityScheme);
+            sort($sortedScheme);
+            $cacheId = implode('|', $sortedScheme) . "|" . $this->_cacheId;
             $configData = $this->configLoader->load($cacheId);
 
             if ($configData) {

--- a/lib/internal/Magento/Framework/Interception/PluginListGenerator.php
+++ b/lib/internal/Magento/Framework/Interception/PluginListGenerator.php
@@ -150,10 +150,17 @@ class PluginListGenerator implements ConfigWriterInterface, ConfigLoaderInterfac
         foreach ($scopes as $scope) {
             $this->scopeConfig->setCurrentScope($scope);
             if (false === isset($this->loadedScopes[$scope])) {
-                if (false === in_array($scope, $this->scopePriorityScheme, true)) {
-                    $this->scopePriorityScheme[] = $scope;
+                // Match PluginList::_loadScopedData() behavior - move scope to end
+                // This ensures cache IDs match between compile-time and runtime
+                $index = array_search($scope, $this->scopePriorityScheme, true);
+                if ($index !== false) {
+                    unset($this->scopePriorityScheme[$index]);
                 }
-                $cacheId = implode('|', $this->scopePriorityScheme) . "|" . $this->cacheId;
+                $this->scopePriorityScheme[] = $scope;
+                // Normalize cache ID by sorting scopes - ensures consistent ID regardless of processing order
+                $sortedScheme = array_values($this->scopePriorityScheme);
+                sort($sortedScheme);
+                $cacheId = implode('|', $sortedScheme) . "|" . $this->cacheId;
                 [
                     $virtualTypes,
                     $this->scopePriorityScheme,

--- a/setup/src/Magento/Setup/Module/Di/App/Task/Operation/PluginListGenerator.php
+++ b/setup/src/Magento/Setup/Module/Di/App/Task/Operation/PluginListGenerator.php
@@ -44,12 +44,8 @@ class PluginListGenerator implements OperationInterface
     public function doOperation()
     {
         $scopes = $this->scopeConfig->getAllScopes();
-        // remove primary scope for production mode as it is only called in developer mode
-        $scopes = array_diff($scopes, ['primary']);
-
-        // sort configuration to have it in the same order on every build
-        ksort($scopes);
-
+        // Cache IDs are now normalized (sorted) in PluginListGenerator::write()
+        // so processing order no longer affects cache ID generation
         $this->configWriter->write($scopes);
     }
 


### PR DESCRIPTION
…so frontend area cache picks up compiled files instead of regenerating on the first request by @jakwinkler

This applies Jakub Winkler's fix of https://github.com/magento/magento2/pull/40407 from https://github.com/magento/magento2/pull/40408