### PR TITLE
Fix GraphQL API by pinning webonyx/graphql-php version to <15.31.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "tedivm/jshrink": "^1.4",
         "tubalmartin/cssmin": "^4.1",
         "web-token/jwt-framework": "^3.4",
-        "webonyx/graphql-php": "^15.0",
+        "webonyx/graphql-php": "^15.0 <15.31.0",
         "wikimedia/less.php": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Magento's GraphQL API broke yesterday due to a breaking change in `webonyx/graphql-php` version 15.31. This works around the issue by pinning the version until such a time as the underlying code is made compatible with the library's intended behavior, or the library fixes the issue from their side.

### Related
<!-- related pull request placeholder -->
https://github.com/webonyx/graphql-php/pull/1869
https://github.com/webonyx/graphql-php/pull/1876
https://github.com/webonyx/graphql-php/pull/1879
https://github.com/webonyx/graphql-php/issues/1874
https://github.com/magento/magento2/issues/40591

### Manual testing scenarios (*)

```bash
curl -s -X POST "http://magento2.test:8000/graphql" \                                                                                                   
    -H 'Content-Type: application/json' \                                                                                                                 
    -d '{"query":"query($s:String){products(filter:{name:{match:$s}}){total_count}}","variables":{"s":"test"}}'  
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

This allows any version 15.x below 15.31. If/when a fixed version comes out, we can add `|| ^15.32` or such.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
