### PR TITLE
Trim whitespace from address fields before database save

### DIFF
--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -611,8 +611,70 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
     public function beforeSave()
     {
         parent::beforeSave();
+        $this->trimAddressFields();
         $this->getRegion();
         return $this;
+    }
+
+    /**
+     * Trim leading and trailing whitespace (including Unicode) from all string address fields
+     *
+     * Street is stored as a newline-joined string by setData(), so only the
+     * string branch is needed — each line is trimmed individually.
+     *
+     * @return void
+     */
+    protected function trimAddressFields(): void
+    {
+        $stringFields = [
+            'firstname',
+            'lastname',
+            'middlename',
+            'prefix',
+            'suffix',
+            'company',
+            'city',
+            'region',
+            'telephone',
+            'fax',
+            'postcode',
+            'vat_id',
+            'email',
+        ];
+
+        foreach ($stringFields as $field) {
+            $value = $this->getData($field);
+
+            if (is_string($value)) {
+                $this->setData($field, $this->unicodeTrim($value));
+            }
+        }
+
+        $street = $this->getData('street');
+
+        if (is_string($street)) {
+            $lines = explode("\n", $street);
+            $this->setData('street', implode("\n", array_map([$this, 'unicodeTrim'], $lines)));
+        } elseif (is_array($street)) {
+            $this->setData('street', array_map(
+                fn ($line) => is_string($line) ? $this->unicodeTrim($line) : $line,
+                $street,
+            ));
+        }
+    }
+
+    /**
+     * Trim ASCII and Unicode whitespace from both ends of a string
+     *
+     * Handles non-breaking spaces (U+00A0), zero-width spaces (U+200B),
+     * and other Unicode whitespace that PHP's trim() does not strip.
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function unicodeTrim(string $value): string
+    {
+        return preg_replace('/^\s+|\s+$/u', '', $value) ?? $value;
     }
 
     /**

--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -667,14 +667,15 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
      * Trim ASCII and Unicode whitespace from both ends of a string
      *
      * Handles non-breaking spaces (U+00A0), zero-width spaces (U+200B),
-     * and other Unicode whitespace that PHP's trim() does not strip.
+     * zero-width joiners/non-joiners, byte order marks, and other
+     * Unicode whitespace that PHP's trim() does not strip.
      *
      * @param string $value
      * @return string
      */
     protected function unicodeTrim(string $value): string
     {
-        return preg_replace('/^\s+|\s+$/u', '', $value) ?? $value;
+        return preg_replace('/^[\s\x{200B}\x{200C}\x{200D}\x{FEFF}]+|[\s\x{200B}\x{200C}\x{200D}\x{FEFF}]+$/u', '', $value) ?? $value;
     }
 
     /**

--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -675,7 +675,10 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
      */
     protected function unicodeTrim(string $value): string
     {
-        return preg_replace('/^[\s\x{200B}\x{200C}\x{200D}\x{FEFF}]+|[\s\x{200B}\x{200C}\x{200D}\x{FEFF}]+$/u', '', $value) ?? $value;
+        $pattern = '/^[\s\x{200B}\x{200C}\x{200D}\x{FEFF}]+'
+            . '|[\s\x{200B}\x{200C}\x{200D}\x{FEFF}]+$/u';
+
+        return preg_replace($pattern, '', $value) ?? $value;
     }
 
     /**

--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -610,8 +610,8 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
      */
     public function beforeSave()
     {
-        parent::beforeSave();
         $this->trimAddressFields();
+        parent::beforeSave();
         $this->getRegion();
         return $this;
     }

--- a/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
@@ -575,6 +575,128 @@ class AbstractAddressTest extends TestCase
         $this->assertEquals(["Street Line 1 Street Line 2 Street Line 3 Street Line 4"], $result);
     }
 
+    public function testBeforeSaveTrimsStringFields(): void
+    {
+        $this->model->setData('firstname', '  John  ');
+        $this->model->setData('lastname', '  Doe  ');
+        $this->model->setData('middlename', '  M  ');
+        $this->model->setData('prefix', '  Mr  ');
+        $this->model->setData('suffix', '  Jr  ');
+        $this->model->setData('company', '  Acme Corp  ');
+        $this->model->setData('city', '  Burlington  ');
+        $this->model->setData('telephone', '  555-1234  ');
+        $this->model->setData('fax', '  555-5678  ');
+        $this->model->setData('postcode', '  05401  ');
+        $this->model->setData('vat_id', '  VAT123  ');
+        $this->model->setData('email', '  test@example.com  ');
+
+        $this->model->beforeSave();
+
+        $this->assertEquals('John', $this->model->getData('firstname'));
+        $this->assertEquals('Doe', $this->model->getData('lastname'));
+        $this->assertEquals('M', $this->model->getData('middlename'));
+        $this->assertEquals('Mr', $this->model->getData('prefix'));
+        $this->assertEquals('Jr', $this->model->getData('suffix'));
+        $this->assertEquals('Acme Corp', $this->model->getData('company'));
+        $this->assertEquals('Burlington', $this->model->getData('city'));
+        $this->assertEquals('555-1234', $this->model->getData('telephone'));
+        $this->assertEquals('555-5678', $this->model->getData('fax'));
+        $this->assertEquals('05401', $this->model->getData('postcode'));
+        $this->assertEquals('VAT123', $this->model->getData('vat_id'));
+        $this->assertEquals('test@example.com', $this->model->getData('email'));
+    }
+
+    public function testBeforeSaveTrimsStreetArrayImplodedToString(): void
+    {
+        // setData() implodes street arrays to newline-joined strings via _implodeArrayValues()
+        $this->model->setData('street', ['  123 Main St  ', '  Apt 4  ']);
+
+        $this->model->beforeSave();
+
+        // After implode + trim, stored as a newline-joined string with each line trimmed
+        $this->assertEquals("123 Main St\nApt 4", $this->model->getData('street'));
+    }
+
+    public function testBeforeSaveTrimsStreetString(): void
+    {
+        $this->model->setData('street', '  123 Main St  ');
+
+        $this->model->beforeSave();
+
+        $this->assertEquals('123 Main St', $this->model->getData('street'));
+    }
+
+    public function testBeforeSaveTrimsEachLineInStreetString(): void
+    {
+        $this->model->setData('street', "street 1\n street 2");
+
+        $this->model->beforeSave();
+
+        $this->assertEquals("street 1\nstreet 2", $this->model->getData('street'));
+    }
+
+    public function testBeforeSaveTrimsRegionField(): void
+    {
+        $this->model->setData('region', '  Vermont  ');
+
+        $this->model->beforeSave();
+
+        $this->assertEquals('Vermont', $this->model->getData('region'));
+    }
+
+    public function testBeforeSaveTrimsUnicodeWhitespace(): void
+    {
+        $nbsp = "\xC2\xA0"; // U+00A0 NON-BREAKING SPACE
+        $zeroWidth = "\xE2\x80\x8B"; // U+200B ZERO WIDTH SPACE
+
+        $this->model->setData('firstname', $nbsp . 'John' . $nbsp);
+        $this->model->setData('city', $zeroWidth . 'Burlington' . $zeroWidth);
+        $this->model->setData('street', $nbsp . '123 Main St' . $nbsp);
+
+        $this->model->beforeSave();
+
+        $this->assertEquals('John', $this->model->getData('firstname'));
+        $this->assertEquals('Burlington', $this->model->getData('city'));
+        $this->assertEquals('123 Main St', $this->model->getData('street'));
+    }
+
+    public function testBeforeSaveHandlesNullFields(): void
+    {
+        $this->model->setData('firstname', null);
+        $this->model->setData('company', null);
+        $this->model->setData('street', null);
+
+        $this->model->beforeSave();
+
+        $this->assertNull($this->model->getData('firstname'));
+        $this->assertNull($this->model->getData('company'));
+        $this->assertNull($this->model->getData('street'));
+    }
+
+    public function testBeforeSaveLeavesNonStringFieldsUntouched(): void
+    {
+        $this->model->setData('postcode', 12345);
+        $this->model->setData('firstname', '');
+
+        $this->model->beforeSave();
+
+        $this->assertSame(12345, $this->model->getData('postcode'));
+        $this->assertSame('', $this->model->getData('firstname'));
+    }
+
+    public function testBeforeSaveIsIdempotent(): void
+    {
+        $this->model->setData('firstname', 'John');
+        $this->model->setData('city', 'Burlington');
+        $this->model->setData('street', "123 Main St\nApt 4");
+
+        $this->model->beforeSave();
+
+        $this->assertEquals('John', $this->model->getData('firstname'));
+        $this->assertEquals('Burlington', $this->model->getData('city'));
+        $this->assertEquals("123 Main St\nApt 4", $this->model->getData('street'));
+    }
+
     protected function tearDown(): void
     {
         $this->objectManager->setBackwardCompatibleProperty(

--- a/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
@@ -81,7 +81,9 @@ class AbstractAddressTest extends TestCase
 
     protected function setUp(): void
     {
+        $eventManagerMock = $this->getMockForAbstractClass(\Magento\Framework\Event\ManagerInterface::class);
         $this->contextMock = $this->createMock(Context::class);
+        $this->contextMock->method('getEventDispatcher')->willReturn($eventManagerMock);
         $this->registryMock = $this->createMock(Registry::class);
         $this->directoryDataMock = $this->createMock(Data::class);
         $this->eavConfigMock = $this->createMock(Config::class);

--- a/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
@@ -81,7 +81,7 @@ class AbstractAddressTest extends TestCase
 
     protected function setUp(): void
     {
-        $eventManagerMock = $this->getMockForAbstractClass(\Magento\Framework\Event\ManagerInterface::class);
+        $eventManagerMock = $this->createMock(\Magento\Framework\Event\ManagerInterface::class);
         $this->contextMock = $this->createMock(Context::class);
         $this->contextMock->method('getEventDispatcher')->willReturn($eventManagerMock);
         $this->registryMock = $this->createMock(Registry::class);


### PR DESCRIPTION
## Summary

- Add `trimAddressFields()` to `AbstractAddress::beforeSave()` to trim leading/trailing whitespace (including Unicode) from all string address fields before persistence
- Covers both checkout (`Quote\Address`) and customer address (`Customer\Address`) save paths since both extend `AbstractAddress`
- Uses `preg_replace` with `/u` flag to also strip Unicode whitespace (non-breaking spaces, zero-width spaces)
- Includes 9 unit tests covering all trimmed fields, street handling, Unicode whitespace, null safety, and edge cases

Fixes https://github.com/mage-os/mageos-magento2/issues/214

## Fields trimmed

`firstname`, `lastname`, `middlename`, `prefix`, `suffix`, `company`, `city`, `region`, `telephone`, `fax`, `postcode`, `vat_id`, `email`, and each line of the `street` field.

## Test plan

- [ ] Verify checkout (guest): enter address fields with leading/trailing spaces → confirm trimmed values in `sales_order_address`
- [ ] Verify customer address add/edit: enter fields with spaces → confirm trimmed on save
- [ ] Verify existing orders/addresses are unaffected (trim only runs on new saves)
- [ ] Run unit tests: `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php`