### PR TITLE
Update graphql-php version constraints (fixes #212)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "tedivm/jshrink": "^1.4",
         "tubalmartin/cssmin": "^4.1",
         "web-token/jwt-framework": "^3.4",
-        "webonyx/graphql-php": "^15.0 !=15.31.0 !=15.31.1"
+        "webonyx/graphql-php": "^15.0 !=15.31.0 !=15.31.1",
         "wikimedia/less.php": "^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "tedivm/jshrink": "^1.4",
         "tubalmartin/cssmin": "^4.1",
         "web-token/jwt-framework": "^3.4",
-        "webonyx/graphql-php": "^15.0 <15.31.0",
+        "webonyx/graphql-php": "^15.0 !=15.31.0 !=15.31.1"
         "wikimedia/less.php": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Fixes #212

Allows installation of Mage-OS with latest `webonyx/graphql-php`, which is necessary due to a security bulletin and update in that package.

Context:

> peterjaap — 5:11 AM
> This change now introduces an issue concerning this advisory; https://github.com/advisories/GHSA-68jq-c3rv-pcrr
> 
> We should update to 15.31.5, but can't due to the fixed constraint.  I've now worked around it by adding this to composer.json; "webonyx/graphql-php": "v15.31.5 as v15.30.2",
> GitHub
> [GHSA-68jq-c3rv-pcrr - GitHub Advisory Database](https://github.com/advisories/GHSA-68jq-c3rv-pcrr)
> graphql-php is affected by a Denial of Service via quadratic complexity in OverlappingFieldsCanBeMerged validation
> Image
> Ryan Hoerr — 7:56 AM
> Thanks. Can you confirm the latest works with Magento's GraphQL API? (or @Damien Retzinger?) I saw conflicting reports as far as 15.31.2 fixing it or not.
> Damien Retzinger — 7:56 AM
> 15.31.2 works
> I upgraded to whatever the latest was last week without issue.
> 15.31.4, to be precise
> Ryan Hoerr — 8:00 AM
> Okay, we'll need to update the constraint here then and push a new patch release for it. https://github.com/mage-os/mageos-magento2/issues/212