### PR TITLE
Add swissup/module-ignition as require-dev starting with Mage-OS 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,7 @@
         "phpmd/phpmd": "^3@dev",
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^12.0",
+        "swissup/module-ignition": "^1.1",
         "symfony/finder": "^7.4"
     },
     "suggest": {


### PR DESCRIPTION
This would add https://github.com/swissup/module-ignition as a dev dependency of Mage-OS, starting with the 3.0 release.

This gives a meaningful improvement to exception pages in dev mode, including nice styling and code links to integrated IDEs, powered by https://github.com/spatie/ignition .

It's require-dev, so it would not be installed or have any impact on production sites (assuming they properly `composer install --no-dev`).