### PR TITLE
Add return type to MessageQueue command execute method

### DIFF
--- a/app/code/Magento/MessageQueue/Console/QueueConfigStatusCommand.php
+++ b/app/code/Magento/MessageQueue/Console/QueueConfigStatusCommand.php
@@ -48,7 +48,7 @@ class QueueConfigStatusCommand extends Command
     /**
      * @inheritdoc
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $hasChanges = false;


### PR DESCRIPTION
Fixes this error with the merged changes from upstream + Symfony 7

```
Declaration of Magento\MessageQueue\Console\QueueConfigStatusCommand::execute(Symfony\Component\Console\Input\InputInterface $input,
  Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface
  $input, Symfony\Component\Console\Output\OutputInterface $output): int
```