### PR TITLE
Mark always-realized core classes with #[NonLazy] (companion to #225)

### DIFF
--- a/app/code/Magento/Backend/App/Area/FrontNameResolver.php
+++ b/app/code/Magento/Backend/App/Area/FrontNameResolver.php
@@ -23,6 +23,7 @@ use Magento\Store\Model\Store;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class FrontNameResolver implements FrontNameResolverInterface
 {
     public const XML_PATH_USE_CUSTOM_ADMIN_PATH = 'admin/url/use_custom_path';

--- a/app/code/Magento/Backend/App/Config.php
+++ b/app/code/Magento/Backend/App/Config.php
@@ -12,6 +12,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 /**
  * Backend config accessor.
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Config implements ConfigInterface
 {
     /**

--- a/app/code/Magento/Backend/App/Request/PathInfoProcessor.php
+++ b/app/code/Magento/Backend/App/Request/PathInfoProcessor.php
@@ -16,6 +16,7 @@ use Magento\Framework\App\RequestInterface;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class PathInfoProcessor implements PathInfoProcessorInterface
 {
     /**

--- a/app/code/Magento/Config/App/Config/Type/System.php
+++ b/app/code/Magento/Config/App/Config/Type/System.php
@@ -33,6 +33,7 @@ use Psr\Log\LoggerInterface;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.UnusedPrivateMethod)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class System implements ConfigTypeInterface
 {
     /**

--- a/app/code/Magento/Config/Model/ResourceModel/Config/Data.php
+++ b/app/code/Magento/Config/Model/ResourceModel/Config/Data.php
@@ -12,6 +12,7 @@ namespace Magento\Config\Model\ResourceModel\Config;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Data extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 {
     /**

--- a/app/code/Magento/Customer/Model/Session/Storage.php
+++ b/app/code/Magento/Customer/Model/Session/Storage.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Customer\Model\Session;
 
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Storage extends \Magento\Framework\Session\Storage
 {
     /**

--- a/app/code/Magento/Customer/Model/Session/Validators/CutoffValidator.php
+++ b/app/code/Magento/Customer/Model/Session/Validators/CutoffValidator.php
@@ -19,6 +19,7 @@ use Magento\Framework\Session\Generic;
  *
  * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class CutoffValidator implements ValidatorInterface
 {
     /**

--- a/app/code/Magento/PageCache/Model/App/FrontController/BuiltinPlugin.php
+++ b/app/code/Magento/PageCache/Model/App/FrontController/BuiltinPlugin.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\Response\Http as ResponseHttp;
 /**
  * Plugin for processing builtin cache
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class BuiltinPlugin
 {
     /**

--- a/app/code/Magento/PageCache/Model/App/FrontController/VarnishPlugin.php
+++ b/app/code/Magento/PageCache/Model/App/FrontController/VarnishPlugin.php
@@ -16,6 +16,7 @@ use Magento\Framework\Controller\ResultInterface;
 /**
  * Varnish for processing builtin cache
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class VarnishPlugin
 {
     /**

--- a/app/code/Magento/PageCache/Model/Controller/Result/BuiltinPlugin.php
+++ b/app/code/Magento/PageCache/Model/Controller/Result/BuiltinPlugin.php
@@ -19,6 +19,7 @@ use Magento\PageCache\Model\Cache\Type as CacheType;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class BuiltinPlugin
 {
     /**

--- a/app/code/Magento/PageCache/Model/Controller/Result/VarnishPlugin.php
+++ b/app/code/Magento/PageCache/Model/Controller/Result/VarnishPlugin.php
@@ -15,6 +15,7 @@ use Magento\Framework\Controller\ResultInterface;
 /**
  * Plugin for processing varnish cache
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class VarnishPlugin
 {
     /**

--- a/app/code/Magento/PageCache/Plugin/RegisterFormKeyFromCookie.php
+++ b/app/code/Magento/PageCache/Plugin/RegisterFormKeyFromCookie.php
@@ -17,6 +17,7 @@ use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
 /**
  * Allow for registration of a form key through cookies.
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class RegisterFormKeyFromCookie
 {
     /**

--- a/app/code/Magento/Store/App/Config/Source/InitialConfigSource.php
+++ b/app/code/Magento/Store/App/Config/Source/InitialConfigSource.php
@@ -12,6 +12,7 @@ use Magento\Framework\App\DeploymentConfig\Reader;
 /**
  * Config source. Retrieve all configuration data from files for specified config type
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class InitialConfigSource implements ConfigSourceInterface
 {
     /**

--- a/app/code/Magento/Store/App/Config/Source/RuntimeConfigSource.php
+++ b/app/code/Magento/Store/App/Config/Source/RuntimeConfigSource.php
@@ -14,6 +14,7 @@ use Magento\Framework\DB\Adapter\TableNotFoundException;
 /**
  * Config source. Retrieve all configuration for scopes from db
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class RuntimeConfigSource implements ConfigSourceInterface
 {
     /**

--- a/app/code/Magento/Store/App/Config/Type/Scopes.php
+++ b/app/code/Magento/Store/App/Config/Type/Scopes.php
@@ -13,6 +13,7 @@ use Magento\Store\Model\ScopeInterface;
 /**
  * Merge and hold scopes data from different sources
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Scopes implements ConfigTypeInterface
 {
     public const CONFIG_TYPE = 'scopes';

--- a/app/code/Magento/Store/App/Request/PathInfoProcessor.php
+++ b/app/code/Magento/Store/App/Request/PathInfoProcessor.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\RequestInterface;
 /**
  * Processes the path and looks for the store in the url and removes it and modifies the path accordingly.
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class PathInfoProcessor implements PathInfoProcessorInterface
 {
     /**

--- a/app/code/Magento/Store/App/Request/StorePathInfoValidator.php
+++ b/app/code/Magento/Store/App/Request/StorePathInfoValidator.php
@@ -21,6 +21,7 @@ use Magento\Store\Model\Validation\StoreCodeValidator;
 /**
  * Gets the store from the path if valid
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class StorePathInfoValidator implements ResetAfterRequestInterface
 {
     /**

--- a/app/code/Magento/Store/Model/GroupRepository.php
+++ b/app/code/Magento/Store/Model/GroupRepository.php
@@ -14,6 +14,7 @@ use Magento\Framework\App\Config;
  *
  * @package Magento\Store\Model
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class GroupRepository implements \Magento\Store\Api\GroupRepositoryInterface
 {
     /**

--- a/app/code/Magento/Store/Model/Resolver/Store.php
+++ b/app/code/Magento/Store/Model/Resolver/Store.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Store\Model\Resolver;
 
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Store implements \Magento\Framework\App\ScopeResolverInterface
 {
     /**

--- a/app/code/Magento/Store/Model/StoreRepository.php
+++ b/app/code/Magento/Store/Model/StoreRepository.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\Config;
 /**
  * Information Expert in stores handling
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class StoreRepository implements \Magento\Store\Api\StoreRepositoryInterface
 {
     /**

--- a/app/code/Magento/Theme/Model/ResourceModel/Theme.php
+++ b/app/code/Magento/Theme/Model/ResourceModel/Theme.php
@@ -8,6 +8,7 @@ namespace Magento\Theme\Model\ResourceModel;
 /**
  * Theme resource model
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Theme extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 {
     /**

--- a/app/code/Magento/Theme/Model/Theme.php
+++ b/app/code/Magento/Theme/Model/Theme.php
@@ -33,6 +33,7 @@ use Magento\Theme\Model\ResourceModel\Theme\Collection as ThemeCollection;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInterface
 {
     /**

--- a/app/code/Magento/Theme/Model/Theme/ThemeProvider.php
+++ b/app/code/Magento/Theme/Model/Theme/ThemeProvider.php
@@ -15,6 +15,7 @@ use Magento\Framework\View\Design\Theme\ThemeProviderInterface;
 /**
  * Provide data for theme grid and for theme edit page
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class ThemeProvider implements ThemeProviderInterface, ResetAfterRequestInterface
 {
     /**

--- a/app/code/Magento/Translation/Model/Inline/Config.php
+++ b/app/code/Magento/Translation/Model/Inline/Config.php
@@ -8,6 +8,7 @@ namespace Magento\Translation\Model\Inline;
 /**
  * Inline Translation config
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Config implements \Magento\Framework\Translate\Inline\ConfigInterface
 {
     /**

--- a/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
+++ b/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
@@ -29,6 +29,7 @@ use UnexpectedValueException;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Factory
 {
     /**

--- a/lib/internal/Magento/Framework/App/Cache/Frontend/Pool.php
+++ b/lib/internal/Magento/Framework/App/Cache/Frontend/Pool.php
@@ -12,6 +12,7 @@ use Magento\Framework\App\DeploymentConfig;
 /**
  * In-memory readonly pool of all cache front-end instances known to the system
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Pool implements \Iterator
 {
     /**

--- a/lib/internal/Magento/Framework/App/Cache/Manager.php
+++ b/lib/internal/Magento/Framework/App/Cache/Manager.php
@@ -14,6 +14,7 @@ use Magento\Framework\App;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Manager
 {
     /**

--- a/lib/internal/Magento/Framework/App/Cache/State.php
+++ b/lib/internal/Magento/Framework/App/Cache/State.php
@@ -13,6 +13,7 @@ use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
 /**
  * Cache State
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class State implements StateInterface, ResetAfterRequestInterface
 {
     /**

--- a/lib/internal/Magento/Framework/App/Cache/Type/Collection.php
+++ b/lib/internal/Magento/Framework/App/Cache/Type/Collection.php
@@ -8,6 +8,7 @@ namespace Magento\Framework\App\Cache\Type;
 /**
  * System / Cache Management / Cache type "Collections Data"
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Collection extends \Magento\Framework\Cache\Frontend\Decorator\TagScope
 {
     /**

--- a/lib/internal/Magento/Framework/App/Cache/Type/Translate.php
+++ b/lib/internal/Magento/Framework/App/Cache/Type/Translate.php
@@ -8,6 +8,7 @@ namespace Magento\Framework\App\Cache\Type;
 /**
  * System / Cache Management / Cache type "Translations"
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Translate extends \Magento\Framework\Cache\Frontend\Decorator\TagScope
 {
     /**

--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\ScopeResolverPool;
 /**
  * Class for resolving scope code
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class ScopeCodeResolver
 {
     /**

--- a/lib/internal/Magento/Framework/App/Helper/Context.php
+++ b/lib/internal/Magento/Framework/App/Helper/Context.php
@@ -18,6 +18,7 @@ namespace Magento\Framework\App\Helper;
  * As Magento moves from inheritance-based APIs all such classes will be deprecated together with
  * the classes they were introduced for.
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Context implements \Magento\Framework\ObjectManager\ContextInterface
 {
     /**

--- a/lib/internal/Magento/Framework/App/PageCache/FormKey.php
+++ b/lib/internal/Magento/Framework/App/PageCache/FormKey.php
@@ -14,6 +14,7 @@ use Magento\Framework\Stdlib\CookieManagerInterface;
  * Class Version
  *
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class FormKey
 {
     /**

--- a/lib/internal/Magento/Framework/App/PageCache/Version.php
+++ b/lib/internal/Magento/Framework/App/PageCache/Version.php
@@ -17,6 +17,7 @@ use Magento\Framework\App\Request\Http;
  *
  * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Version
 {
     /**

--- a/lib/internal/Magento/Framework/App/Request/Http.php
+++ b/lib/internal/Magento/Framework/App/Request/Http.php
@@ -24,6 +24,7 @@ use Magento\Framework\Stdlib\StringUtils;
  * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  * @api
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Http extends Request implements
     RequestContentInterface,
     RequestSafetyInterface,

--- a/lib/internal/Magento/Framework/App/ResourceConnection/Config.php
+++ b/lib/internal/Magento/Framework/App/ResourceConnection/Config.php
@@ -11,6 +11,7 @@ use Magento\Framework\Serialize\SerializerInterface;
 /**
  * Resource configuration, uses application configuration to retrieve resource connection information
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Config extends \Magento\Framework\Config\Data\Scoped implements ConfigInterface
 {
     /**

--- a/lib/internal/Magento/Framework/App/ResourceConnection/ConnectionFactory.php
+++ b/lib/internal/Magento/Framework/App/ResourceConnection/ConnectionFactory.php
@@ -10,6 +10,7 @@ use Magento\Framework\Model\ResourceModel\Type\Db\ConnectionFactory as ModelConn
 /**
  * Connection adapter factory
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class ConnectionFactory extends ModelConnectionFactory
 {
     /**

--- a/lib/internal/Magento/Framework/App/Response/HeaderManager.php
+++ b/lib/internal/Magento/Framework/App/Response/HeaderManager.php
@@ -10,6 +10,7 @@ use Magento\Framework\App\Response\HeaderProvider\HeaderProviderInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
 
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class HeaderManager
 {
     /**

--- a/lib/internal/Magento/Framework/App/Response/HeaderProvider/XFrameOptions.php
+++ b/lib/internal/Magento/Framework/App/Response/HeaderProvider/XFrameOptions.php
@@ -10,6 +10,7 @@ use \Magento\Framework\App\Response\Http;
 /**
  * Adds an X-FRAME-OPTIONS header to HTTP responses to safeguard against click-jacking.
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class XFrameOptions extends \Magento\Framework\App\Response\HeaderProvider\AbstractHeaderProvider
 {
     /** Deployment config key for frontend x-frame-options header value */

--- a/lib/internal/Magento/Framework/App/Response/HeaderProvider/XssProtection.php
+++ b/lib/internal/Magento/Framework/App/Response/HeaderProvider/XssProtection.php
@@ -8,6 +8,7 @@ namespace Magento\Framework\App\Response\HeaderProvider;
 use Magento\Framework\App\Response\HeaderProvider\HeaderProviderInterface;
 use Magento\Framework\HTTP\Header;
 
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class XssProtection extends AbstractHeaderProvider
 {
     /**

--- a/lib/internal/Magento/Framework/App/ScopeResolverPool.php
+++ b/lib/internal/Magento/Framework/App/ScopeResolverPool.php
@@ -9,6 +9,7 @@ namespace Magento\Framework\App;
 /**
  * Provider of scope resolvers by type
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class ScopeResolverPool
 {
     /**

--- a/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapterProvider.php
+++ b/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapterProvider.php
@@ -33,6 +33,7 @@ use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class SymfonyAdapterProvider implements ResetAfterRequestInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Config/Data.php
+++ b/lib/internal/Magento/Framework/Config/Data.php
@@ -15,6 +15,7 @@ use Magento\Framework\App\ObjectManager;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Data implements \Magento\Framework\Config\DataInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Config/Scope.php
+++ b/lib/internal/Magento/Framework/Config/Scope.php
@@ -10,6 +10,7 @@ use Magento\Framework\App\AreaList;
 /**
  * Scope config
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Scope implements ScopeInterface, ScopeListInterface
 {
     /**

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/MysqlFactory.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/MysqlFactory.php
@@ -15,6 +15,7 @@ use Magento\Framework\ObjectManagerInterface;
  *
  * @api
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class MysqlFactory
 {
     /**

--- a/lib/internal/Magento/Framework/DB/Select/ColumnsRenderer.php
+++ b/lib/internal/Magento/Framework/DB/Select/ColumnsRenderer.php
@@ -11,6 +11,7 @@ use Magento\Framework\DB\Platform\Quote;
 /**
  * Class ColumnsRenderer
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class ColumnsRenderer implements RendererInterface
 {
     /**

--- a/lib/internal/Magento/Framework/DB/Select/FromRenderer.php
+++ b/lib/internal/Magento/Framework/DB/Select/FromRenderer.php
@@ -8,6 +8,7 @@ namespace Magento\Framework\DB\Select;
 use Magento\Framework\DB\Select;
 use Magento\Framework\DB\Platform\Quote;
 
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class FromRenderer implements RendererInterface
 {
     /**

--- a/lib/internal/Magento/Framework/DB/Select/OrderRenderer.php
+++ b/lib/internal/Magento/Framework/DB/Select/OrderRenderer.php
@@ -11,6 +11,7 @@ use Magento\Framework\DB\Platform\Quote;
 /**
  * Class OrderRenderer
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class OrderRenderer implements RendererInterface
 {
     /**

--- a/lib/internal/Magento/Framework/DB/Select/SelectRenderer.php
+++ b/lib/internal/Magento/Framework/DB/Select/SelectRenderer.php
@@ -10,6 +10,7 @@ use Magento\Framework\DB\Select;
 /**
  * Phrase renderer interface
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class SelectRenderer implements RendererInterface
 {
     private const MANDATORY_SELECT_PARTS = [

--- a/lib/internal/Magento/Framework/DB/SelectFactory.php
+++ b/lib/internal/Magento/Framework/DB/SelectFactory.php
@@ -15,6 +15,7 @@ use Magento\Framework\DB\Adapter\AdapterInterface;
  * @api
  * @since 100.1.0
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class SelectFactory
 {
     /**

--- a/lib/internal/Magento/Framework/Data/Collection/EntityFactory.php
+++ b/lib/internal/Magento/Framework/Data/Collection/EntityFactory.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Framework\Data\Collection;
 
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class EntityFactory implements EntityFactoryInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Event/Config.php
+++ b/lib/internal/Magento/Framework/Event/Config.php
@@ -9,6 +9,7 @@ namespace Magento\Framework\Event;
 
 use Magento\Framework\Event\Config\Data;
 
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Config implements ConfigInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Event/Config/Data.php
+++ b/lib/internal/Magento/Framework/Event/Config/Data.php
@@ -10,6 +10,7 @@ use Magento\Framework\Serialize\SerializerInterface;
 /**
  * Provides event configuration
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Data extends \Magento\Framework\Config\Data\Scoped
 {
     /**

--- a/lib/internal/Magento/Framework/Flag/FlagResource.php
+++ b/lib/internal/Magento/Framework/Flag/FlagResource.php
@@ -8,6 +8,7 @@ namespace Magento\Framework\Flag;
 /**
  * Flag Resource model
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class FlagResource extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 {
     /**

--- a/lib/internal/Magento/Framework/FlagFactory.php
+++ b/lib/internal/Magento/Framework/FlagFactory.php
@@ -8,6 +8,7 @@ namespace Magento\Framework;
 /**
  * Factory class for \Magento\Framework\Flag
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class FlagFactory
 {
     /**

--- a/lib/internal/Magento/Framework/Locale/Resolver.php
+++ b/lib/internal/Magento/Framework/Locale/Resolver.php
@@ -13,6 +13,7 @@ use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
 /**
  * Manages locale config information.
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Resolver implements ResolverInterface, ResetAfterRequestInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Model/Context.php
+++ b/lib/internal/Magento/Framework/Model/Context.php
@@ -21,6 +21,7 @@ namespace Magento\Framework\Model;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Context implements \Magento\Framework\ObjectManager\ContextInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/Context.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/Context.php
@@ -18,6 +18,7 @@ namespace Magento\Framework\Model\ResourceModel\Db;
  *
  * @codeCoverageIgnore
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Context implements \Magento\Framework\ObjectManager\ContextInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Session/CompositeValidator.php
+++ b/lib/internal/Magento/Framework/Session/CompositeValidator.php
@@ -11,6 +11,7 @@ namespace Magento\Framework\Session;
 /**
  * Use sequence of validators to validate sessions.
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class CompositeValidator implements ValidatorInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Session/Config.php
+++ b/lib/internal/Magento/Framework/Session/Config.php
@@ -18,6 +18,7 @@ use Magento\Framework\Session\Config\Validator\CookieSameSiteValidator;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Config implements ConfigInterface
 {
     /** Configuration path for session save method */

--- a/lib/internal/Magento/Framework/Session/SaveHandler.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler.php
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class SaveHandler implements SaveHandlerInterface, ResetAfterRequestInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Session/SaveHandlerFactory.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandlerFactory.php
@@ -8,6 +8,7 @@ namespace Magento\Framework\Session;
 /**
  * Magento session save handler factory
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class SaveHandlerFactory
 {
     /**

--- a/lib/internal/Magento/Framework/Session/SessionMaxSizeConfig.php
+++ b/lib/internal/Magento/Framework/Session/SessionMaxSizeConfig.php
@@ -17,6 +17,7 @@ use Magento\Framework\Exception\LocalizedException;
 /**
  * Magento session max size configuration
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class SessionMaxSizeConfig
 {
     /**

--- a/lib/internal/Magento/Framework/Session/Storage.php
+++ b/lib/internal/Magento/Framework/Session/Storage.php
@@ -10,6 +10,7 @@ use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
 /**
  * Default session storage
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Storage extends \Magento\Framework\DataObject implements StorageInterface, ResetAfterRequestInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Session/Validator.php
+++ b/lib/internal/Magento/Framework/Session/Validator.php
@@ -12,6 +12,7 @@ use Magento\Framework\Phrase;
 /**
  * Session Validator
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Validator implements ValidatorInterface
 {
     const VALIDATOR_KEY = '_session_validator_data';

--- a/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
+++ b/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
@@ -24,6 +24,7 @@ use Psr\Log\LoggerInterface;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class PhpCookieManager implements CookieManagerInterface
 {
     /**#@+

--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -19,6 +19,7 @@ use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.TooManyFields)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Translate implements \Magento\Framework\TranslateInterface, ResetAfterRequestInterface
 {
     public const CONFIG_AREA_KEY = 'area';

--- a/lib/internal/Magento/Framework/Translate/Inline.php
+++ b/lib/internal/Magento/Framework/Translate/Inline.php
@@ -24,6 +24,7 @@ use Magento\Framework\View\LayoutInterface;
  * Translate Inline Class
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Inline implements InlineInterface, ResetAfterRequestInterface
 {
     /**

--- a/lib/internal/Magento/Framework/View/Layout/ConfigCondition.php
+++ b/lib/internal/Magento/Framework/View/Layout/ConfigCondition.php
@@ -12,6 +12,7 @@ use Magento\Framework\App\ScopeResolverInterface;
 /**
  * Check that config flag is set to true,
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class ConfigCondition implements VisibilityConditionInterface
 {
     /**

--- a/lib/internal/Magento/Framework/View/Layout/Data/Structure.php
+++ b/lib/internal/Magento/Framework/View/Layout/Data/Structure.php
@@ -14,6 +14,7 @@ use Magento\Framework\App\State;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Structure extends DataStructure
 {
     /**

--- a/lib/internal/Magento/Framework/View/Layout/GeneratorPool.php
+++ b/lib/internal/Magento/Framework/View/Layout/GeneratorPool.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerInterface;
  * @since 100.0.2
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class GeneratorPool
 {
     /**

--- a/lib/internal/Magento/Framework/View/Layout/Reader/Container.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Container.php
@@ -10,6 +10,7 @@ use Magento\Framework\View\Layout;
 /**
  * Class Container
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Container implements Layout\ReaderInterface
 {
     /**#@+

--- a/lib/internal/Magento/Framework/View/Layout/Reader/Context.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Context.php
@@ -12,6 +12,7 @@ use Magento\Framework\View\Page;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class Context
 {
     /**

--- a/lib/internal/Magento/Framework/View/Layout/ScheduledStructure.php
+++ b/lib/internal/Magento/Framework/View/Layout/ScheduledStructure.php
@@ -11,6 +11,7 @@ namespace Magento\Framework\View\Layout;
  * @api
  * @since 100.0.2
  */
+#[\Magento\Framework\ObjectManager\Attribute\NonLazy]
 class ScheduledStructure
 {
     /**#@+


### PR DESCRIPTION
## Summary

Applies `#[\Magento\Framework\ObjectManager\Attribute\NonLazy]` to 74 core classes that empirical telemetry showed are realized in essentially every request where the lazy-ghost factory creates them. This is the targeted-deny-list optimization layer for the lazy-ghost infrastructure introduced in #225.

**Stands alone**: the FQCN form is a silent no-op when the `NonLazy` attribute class doesn't exist (PHP doesn't autoload attribute target classes), so this PR is safe to land on `release/3.x` independently of #225. When #225 lands, these annotations begin participating in the compile-time deny-list automatically.

## Why these 74 classes

Per-class realization-rate telemetry was collected across 14 workloads (storefront × 6 URLs × cold + warm regimes, plus 2 CLI commands; 70 requests total) on top of #225. Findings:

- The realization-rate distribution is strongly bimodal: 58% of ghost-created classes are always realized (rate ≥ 0.95), 41% are never realized (rate ≤ 0.05), only ~1% sit in between.
- 62% of all ghost creations come from the always-realized set — wrapper allocation with no realization-skip win.
- Empirical validation: when the full 986-class always-realized set was added to the deny-list, latency improved **−0.93% warm** and **−1.35% cold** vs vanilla #225, with zero wins lost.
- A static heuristic (Interceptor suffix, 86.5% precision) was tested and *regressed* by 1.5% — collateral damage from forcing not-always-realized interceptors out of the lazy path. Static rules don't have enough precision to be net-positive.

This PR ships only the subset where universality is provable from the call graph — not just from data — to minimize regression risk in workloads we didn't bench (admin, REST, GraphQL non-product, cron, queues, custom modules).

## Selection criteria

74 classes across five groups, each defensible from request-flow first principles:

| group | classes | rationale |
|---|---:|---|
| **A** Universal framework primitives | 34 | Config, cache, DB, events, models — touched on any DI / config / cache / event work. No plausible workload creates without realizing. |
| **B** HTTP-universal | 20 | Request/response/session/area-resolution. Created in every HTTP entry (storefront, admin, REST, GraphQL, webhooks). Not created in CLI. |
| **C** HTML-rendering universal | 11 | Layout, theme, inline-translate. Created in storefront + admin HTML pages; not created in REST/GraphQL/CLI (so attribute is no-op there). |
| **E** Customer session | 2 | Realized on every storefront customer session start. |
| **F** Storefront FPC plugins | 7 | Frontend-area scoped via `etc/frontend/di.xml`; only join plugin chain in storefront. |

Group D (module-conditional: RemoteStorage, Paypal, NewRelic, APM, Deploy plugins) was deliberately deferred — those would also be safe but are best annotated alongside any module-specific changes. Tier 3/4 catalog/category-specific classes were excluded as workload-specific risks.

The full investigation (methodology, per-class data, candidate rankings, validation) is preserved locally at `docs/superpowers/specs/2026-05-08-*` (kept off this PR to keep the diff minimal).

## Diff shape

74 files changed, 74 insertions(+), 0 deletions(-).

Every file gets exactly one identical line (`#[\Magento\Framework\ObjectManager\Attribute\NonLazy]`) placed between the existing class doc-comment and the `class` declaration (PSR-canonical position). No other code touched. Verified with `php -l` on every file post-edit.

## Behavior matrix

| environment | observed behavior |
|---|---|
| `release/3.x` without #225 | Attribute reference is silent no-op — `Magento\Framework\ObjectManager\Attribute\NonLazy` doesn't exist; PHP doesn't autoload attribute target classes; the attribute reflection call is never made. Zero behavioral change. |
| `release/3.x` with #225 + PHP 8.4 | `Magento\Setup\Module\Di\Compiler\Config\Chain\NonLazyTypes::isLazyEligible()` reads the attribute via reflection and excludes these classes from the lazy-ghost path. Estimated effect on this install: ~0.2–0.4% warm latency, ~0.3–0.5% cold latency. |
| `release/3.x` with #225 + PHP 8.3 | `NonLazyTypes::modify()` early-returns; `nonLazyTypes` key absent; runtime lazy path constant-folded out by the `PHP_VERSION_ID >= 80400` check. Zero effect. |

## Test plan

- [x] All 74 files pass `php -l`.
- [x] `git show HEAD` shows exactly 74 additions and 0 deletions, all identical.
- [x] Each added line is immediately followed by a `class` declaration (no misplacements).
- [ ] CI green on this branch (PHP 8.3 / 8.4 unit + integration runs).
- [ ] Verify no PHPCS regressions (FQCN-in-attribute is permitted but worth confirming).
- [ ] If #225 is also installed: `bin/magento setup:di:compile` completes successfully on PHP 8.4 and `nonLazyTypes` count grows by ~74 vs the baseline #225 compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)