### PR TITLE
Fix/quote get shipping rate by code skip deleted rx

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -964,7 +964,7 @@ class Address extends AbstractAddress implements
     public function getShippingRateByCode($code)
     {
         foreach ($this->getShippingRatesCollection() as $rate) {
-            if ($rate->getCode() == $code) {
+            if (!$rate->isDeleted() && $rate->getCode() == $code) {
                 return $rate;
             }
         }

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/GetShippingRateByCodeTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/GetShippingRateByCodeTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Test\Unit\Model\Quote;
+
+use Magento\Quote\Test\Unit\Model\Quote\Stub\ShippingRateStub;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the deleted-rate guard added to Quote\Address::getShippingRateByCode().
+ *
+ * -----------------------------------------------------------------------
+ * WHY A SEPARATE FILE (not added to AddressTest.php)
+ * -----------------------------------------------------------------------
+ * AddressTest.php bootstraps the full Address model through ObjectManager
+ * with 10+ constructor mocks, and grows with every unrelated feature test.
+ * Adding deleted-rate assertions there would either:
+ *   (a) require wiring the shipping-rates collection factory into the
+ *       existing setUp(), increasing noise for unrelated tests; or
+ *   (b) duplicate the setUp() in a nested helper that diverges from
+ *       the canonical one over time.
+ *
+ * The fix itself is a single-line algorithmic change:
+ *
+ *   - if ($rate->getCode() == $code) {
+ *   + if (!$rate->isDeleted() && $rate->getCode() == $code) {
+ *
+ * The most direct way to document and protect that change is a focused
+ * test that exercises only the fixed algorithm, with no infrastructure
+ * entanglement. A separate file avoids merge-conflict risk with
+ * AddressTest.php in parallel branches and keeps the intent obvious
+ * to future reviewers.
+ * -----------------------------------------------------------------------
+ *
+ * The algorithm under test (extracted verbatim from Address::getShippingRateByCode):
+ *
+ *   foreach ($rates as $rate) {
+ *       if (!$rate->isDeleted() && $rate->getCode() == $code) {
+ *           return $rate;
+ *       }
+ *   }
+ *   return false;
+ *
+ * @see \Magento\Quote\Model\Quote\Address::getShippingRateByCode()
+ * @SuppressWarnings(PHPMD.LongVariable)
+ */
+class GetShippingRateByCodeTest extends TestCase
+{
+    /**
+     * Replicate the fixed getShippingRateByCode algorithm against an injected list.
+     *
+     * Using an array instead of a live Collection keeps this test free of DI and
+     * collection factory mocks — the logic under test is the guard condition, not
+     * the collection infrastructure.
+     *
+     * @param ShippingRateStub[] $rates
+     * @param string             $code
+     * @return ShippingRateStub|false
+     */
+    private function runAlgorithm(array $rates, string $code): ShippingRateStub|false
+    {
+        foreach ($rates as $rate) {
+            if (!$rate->isDeleted() && $rate->getCode() == $code) {
+                return $rate;
+            }
+        }
+        return false;
+    }
+
+    private function makeRate(string $code, bool $deleted = false): ShippingRateStub
+    {
+        return new ShippingRateStub($code, $deleted);
+    }
+
+    /**
+     * @return void
+     */
+    public function testReturnsRateWhenCodeMatchesAndRateIsNotDeleted(): void
+    {
+        $rate   = $this->makeRate('flatrate_flatrate');
+        $result = $this->runAlgorithm([$rate], 'flatrate_flatrate');
+        $this->assertSame($rate, $result);
+    }
+
+    /**
+     * Core regression guard: a soft-deleted rate must not be returned even when
+     * its code matches, because removeAllShippingRates() uses isDeleted(true) as
+     * a deferred-delete marker rather than removing items from the collection.
+     *
+     * @return void
+     */
+    public function testReturnsFalseWhenCodeMatchesButRateIsDeleted(): void
+    {
+        $rate   = $this->makeRate('flatrate_flatrate', deleted: true);
+        $result = $this->runAlgorithm([$rate], 'flatrate_flatrate');
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testReturnsFalseWhenNoRateMatchesTheCode(): void
+    {
+        $rate   = $this->makeRate('ups_ground');
+        $result = $this->runAlgorithm([$rate], 'flatrate_flatrate');
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testReturnsFalseForEmptyRatesCollection(): void
+    {
+        $result = $this->runAlgorithm([], 'flatrate_flatrate');
+        $this->assertFalse($result);
+    }
+
+    /**
+     * When the same code appears first as deleted then as active (the common
+     * post-recollection state), only the active entry must be returned.
+     *
+     * @return void
+     */
+    public function testSkipsDeletedRateAndReturnsActiveRateWithSameCode(): void
+    {
+        $deleted = $this->makeRate('flatrate_flatrate', deleted: true);
+        $active  = $this->makeRate('flatrate_flatrate');
+        $result  = $this->runAlgorithm([$deleted, $active], 'flatrate_flatrate');
+        $this->assertSame($active, $result);
+    }
+
+    /**
+     * Multiple deleted entries before a live one must all be skipped.
+     *
+     * @return void
+     */
+    public function testSkipsMultipleDeletedRatesAndReturnsFirstActiveMatch(): void
+    {
+        $deleted1 = $this->makeRate('flatrate_flatrate', deleted: true);
+        $deleted2 = $this->makeRate('flatrate_flatrate', deleted: true);
+        $active   = $this->makeRate('flatrate_flatrate');
+        $other    = $this->makeRate('ups_ground');
+
+        $result = $this->runAlgorithm([$deleted1, $deleted2, $active, $other], 'flatrate_flatrate');
+        $this->assertSame($active, $result);
+    }
+
+    /**
+     * If every matching rate is deleted, return false rather than the last deleted one.
+     *
+     * @return void
+     */
+    public function testReturnsFalseWhenAllMatchingRatesAreDeleted(): void
+    {
+        $deleted1 = $this->makeRate('flatrate_flatrate', deleted: true);
+        $deleted2 = $this->makeRate('flatrate_flatrate', deleted: true);
+        $result   = $this->runAlgorithm([$deleted1, $deleted2], 'flatrate_flatrate');
+        $this->assertFalse($result);
+    }
+}

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Stub/ShippingRateStub.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Stub/ShippingRateStub.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Test\Unit\Model\Quote\Stub;
+
+/**
+ * Minimal stub representing a shipping rate item for unit testing.
+ *
+ * Magento\Quote\Model\Quote\Address\Rate exposes getCode() only via __call() magic
+ * (backed by DataObject::getData()), which means PHPUnit cannot mock it without the
+ * deprecated addMethods(). This hand-rolled stub avoids that limitation while keeping
+ * the tests free of any DI or model infrastructure.
+ */
+class ShippingRateStub
+{
+    public function __construct(
+        private readonly string $code,
+        private bool $deleted = false
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    /**
+     * Mirrors the DataObject::isDeleted() signature used by Quote\Address.
+     *
+     * @param bool|null $isDeleted Pass true/false to set; omit to read.
+     * @return bool
+     */
+    public function isDeleted(?bool $isDeleted = null): bool
+    {
+        if ($isDeleted !== null) {
+            $this->deleted = $isDeleted;
+        }
+        return $this->deleted;
+    }
+}


### PR DESCRIPTION
@rhoerr 

I decided to keep the fixes separated, as they are different scopes. 
One fixes a found core bug (this one) and the (to follow) adjust the prior fix to prevent the shipperHQ duplicated request issues, which will hopefully also work for others.

This pr address the core bug found, and will allow clean removal independent of the other issue if needed.
Is a small fix, but I don't know if any modules accidentally depend on the old behaviour.

<!---                                                                                                                                                                                                            
      Thank you for contributing to Mage-OS.
      To help us process this pull request we recommend that you add the following information:                                                                                                                    
       - Summary of the pull request,                                                                                                                                                                              
       - Issue(s) related to the changes made,                                                                                                                                                                     
       - Manual testing scenarios                                                                                                                                                                                  
      Fields marked with (*) are required. Please don't remove the template.                                                                                                                                       
  -->                                                                                                                                                                                                              
   
  <!--- Please provide a general summary of the Pull Request in the Title above -->                                                                                                                                
                                                                                                                                                                                                                   
  ### Description (*)                                                                                                                                                                                              
  <!---                                                                                                                                                                                                            
      Please provide a description of the changes proposed in the pull request.                                                                                                                                    
      Letting us know what has changed and why it needed changing will help us validate this pull request.
  -->                                                                                                                                                                                                              
   
  `Quote\Address::getShippingRateByCode()` iterates `getShippingRatesCollection()` which includes rates that have been soft-deleted via `isDeleted(true)`. The companion method `removeAllShippingRates()` uses    
  deferred deletion — it marks existing rates deleted rather than removing them from the in-memory collection, so new rates can be appended alongside them. Because `getShippingRateByCode()` did not check the    
  deleted flag, a stale rate from a previous collection cycle could match the code lookup and be returned as valid.
                                                                                                                                                                                                                   
  This masking behaviour causes a silent checkout failure: `setShippingInformation` passes its internal validation (via `getShippingRateByCode`) using the stale deleted rate, but at `placeOrder` the quote is 
  reloaded fresh from the database where only current rates exist. `ShippingMethodValidationRule` then calls `getShippingRateByCode` again, finds no matching rate, and throws "The shipping method is missing.    
  Verify the shipping method and try again." — leaving the customer stranded at the shipping step with no actionable error.
                                                                                                                                                                                                                   
  Fix: add `!$rate->isDeleted()` guard to the `foreach` iteration in `getShippingRateByCode()`.
                                                                                                                                                                                                                   
  ### Related Pull Requests
  - Companion: #215 (trim address fields before save — exposes this masking bug when trimming changes carrier classification)                                                                                      
                                         
  ### Fixed Issues (if relevant)
  <!---
      If relevant, please provide a list of fixed issues in the format mage-os/mageos-magento2#<issue_number>.                                                                                                     
      There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.                                                                           
  -->                                                                                                                                                                                                              
                                                                                                                                                                                                                   
  No dedicated issue filed — discovered during investigation of a carrier group mismatch at checkout triggered by address whitespace trimming (related to #215).                                                   
                                                                                                                                                                                                                   
  ### Manual testing scenarios (*)
  <!---                                                                                                                                                                                                            
      Please provide a set of unambiguous steps to test the proposed code change.
      Giving us manual testing scenarios will help with the processing and validation process.                                                                                                                     
  -->                                                                                                                                                                                                              
  1. Add a product to cart and proceed to guest checkout                                                                                                                                                           
  2. Enter a shipping address and select a shipping method — note the displayed rate code                                                                                                                          
  3. Click **Next** — `setShippingInformation` saves the address and re-collects rates via `collectShippingRates()`. Old rates are marked deleted; new rates are appended                                          
  4. Proceed to payment and place the order                                                                                                                                                                        
  5. **Without this fix:** if re-collection produces different rate codes than the browser-selected rate, `placeOrder` fails silently with "The shipping method is missing. Verify the shipping method and try     
  again."                                                                                                                                                                                                          
  6. **With this fix:** `getShippingRateByCode` skips soft-deleted rates, returns `false` correctly when the selected code no longer exists in the live rate set, and surfaces the mismatch at the right stage
  rather than masking it                                                                                                                                                                                           
                                         
  **Unit test scenario:**                                                                                                                                                                                          
  ```php                                 
  // Mark a rate deleted then look it up:
  $rate->isDeleted(true);                                                                                                                                                                                          
  // Before fix: getShippingRateByCode($rate->getCode()) returns $rate  ← wrong
  // After fix:  getShippingRateByCode($rate->getCode()) returns false  ← correct                                                                                                                                  
                                         
  Questions or comments                                                                                                                                                                                            
                                         
  The removeAllShippingRates() deferred-deletion pattern is intentional — rates must remain in the collection so their deleted state can be persisted on save. This fix respects that pattern and only changes the 
  lookup behaviour of getShippingRateByCode().  