### PR TITLE
fix: trim address fields before collecting shipping rates

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -1011,6 +1011,7 @@ class Address extends AbstractAddress implements
         }
 
         $this->setCollectShippingRates(false);
+        $this->trimAddressFields();
 
         $this->removeAllShippingRates();
 


### PR DESCRIPTION
## Description                                
                                                                                                                                                                                                                   
  <!-- Please, describe what this Pull Request does. If it's a bug fix, describe the bug first. If it's a new feature, describe what it's adding. -->                                                              
   
  `Quote\Address::collectShippingRates()` calls out to shipping carriers without                                                                                                                                   
  first trimming whitespace from address fields. The companion fix in #215 added
  `trimAddressFields()` to `AbstractAddress::beforeSave()`, which trims fields                                                                                                                                     
  when the address is persisted — but the estimate-shipping-methods API path                                                                                                                                       
  calls `collectShippingRates()` without saving, so `beforeSave()` never fires.                                                                                                                                    
                                                                                                                                                                                                                   
  This PR calls `$this->trimAddressFields()` at the top of                                                                                                                                                         
  `collectShippingRates()`, after the early-return guard and before                                                                                                                                                
  `removeAllShippingRates()`. `trimAddressFields()` is a protected method on                                                                                                                                       
  `AbstractAddress` (added by #215) and is already inherited by `Quote\Address` —                                                                                                                                  
  no new API surface is introduced. Trim is idempotent, so calling it here in                                                                                                                                      
  addition to `beforeSave()` is safe.                                                                                                                                                                              
                                                                                                                                                                                                                   
  ## Related Issue(s)                    
                                                                                                                                                                                                                   
  <!-- Link to related GitHub issues. Use "Closes #NNN" if this PR fully resolves an issue. -->                                                                                                                    
   
  Companion to #215 (trim address fields before save).                                                                                                                                                             
                                         
  ## Motivation and Context                                                                                                                                                                                        
                                         
  <!-- Why is this change required? What problem does it solve? -->

  When a customer checks out, the browser calls `estimate-shipping-methods` to                                                                                                                                     
  populate the shipping step. Carriers receive the address **as typed** — possibly
  with leading/trailing whitespace.                                                                                                                                                                                
                                         
  Later, `setShippingInformation` saves the address (triggering `beforeSave()` →                                                                                                                                   
  `trimAddressFields()`) and then calls `collectShippingRates()` again. If a
  carrier (e.g. ShipperHQ) classifies the address differently after trimming —                                                                                                                                     
  for example, a company name with a leading space changing the                                                                                                                                                    
  residential/commercial tier — the rate code selected at estimate time no longer                                                                                                                                  
  exists in the freshly collected set.                                                                                                                                                                             
                                                                                                                                                                                                                   
  `ShippingMethodValidationRule::validate()` then throws:                                                                                                                                                          
                                                                                                                                                                                                                   
  > "The shipping method is missing."    

  and the customer cannot place the order.                                                                                                                                                                         
   
  Calling `trimAddressFields()` inside `collectShippingRates()` ensures both the                                                                                                                                   
  estimate path and the `setShippingInformation` path send identical (trimmed)
  field values to carriers, producing the same rate codes on both calls.                                                                                                                                           
                                                                                                                                                                                                                   
  ## Screenshots / Reproduction Steps                                                                                                                                                                              
                                                                                                                                                                                                                   
  <!-- Optional: screenshots, steps to reproduce the problem, or before/after comparisons -->                                                                                                                      
   
  1. Have a carrier integration that classifies addresses by company name                                                                                                                                          
     (residential vs commercial).        
  2. Enter a company name with a leading space in the shipping step.                                                                                                                                               
  3. Proceed through checkout — `estimate-shipping-methods` succeeds.                                                                                                                                              
  4. Click **Place Order** → `"The shipping method is missing."` error.                                                                                                                                            
                                                                                                                                                                                                                   
  After this fix, step 4 completes successfully.                                                                                                                                                                   
                                         
  ## Types of Changes                                                                                                                                                                                              
                                         
  <!-- Put an `x` in all boxes that apply. -->                                                                                                                                                                     
   
  - [x] Bug fix (non-breaking change which fixes an issue)                                                                                                                                                         
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
                                                                                                                                                                                                                   
  ## Checklist
                                                                                                                                                                                                                   
  <!-- Go over all the following points, and put an `x` in all boxes that apply. -->                                                                                                                               
   
  - [x] I have read the [CONTRIBUTING](https://github.com/mage-os/mageos-magento2/blob/main/CONTRIBUTING.md) document.                                                                                             
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.                                                                                                                                                          
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests pass.                                                                                                                                                                           
   
  ## Notes for Reviewers                                                                                                                                                                                           
                                         
  <!-- Anything that would help reviewers understand the change faster -->                                                                                                                                         
   
  - The one-line change is in `collectShippingRates()` at the point immediately                                                                                                                                    
    after `setCollectShippingRates(false)` and before `removeAllShippingRates()`.
    This is the earliest safe point: the early-return guard has already exited, so                                                                                                                                 
    trim only runs when a real collection is about to happen.                                                                                                                                                      
                                                                                                                                                                                                                   
  - `trimAddressFields()` is already covered by the tests introduced with #215.                                                                                                                                    
    The change here does not alter the trim logic — only when it runs.                                                                                                                                             
                                                                                                                                                                                                                   
  - A local regression test                                                                                                                                                                                        
    (`Uptactics\PpsTheme\Test\Unit\QuoteAddressCollectShippingRatesTrimTest`)                                                                                                                                      
    verifies that `collectShippingRates()` trims fields when the collect-flag is                                                                                                                                   
    `true` and leaves them untouched when the guard returns early. This test lives                                                                                                                                 
    in the downstream project rather than this PR to avoid merge-conflict risk with                                                                                                                                
    `AddressTest.php` in parallel branches.  