### PR TITLE
fix(Quote/Address): only clear shipping_method when no rates returned

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -1020,7 +1020,10 @@ class Address extends AbstractAddress implements
 
         $found = $this->requestShippingRates();
         if (!$found) {
-            $this->setShippingAmount(0)->setBaseShippingAmount(0)->setShippingMethod('')->setShippingDescription('');
+            $this->setShippingAmount(0)->setBaseShippingAmount(0);
+            if (!$this->getShippingRatesCollection()->getSize()) {
+                $this->setShippingMethod('')->setShippingDescription('');
+            }
         }
 
         return $this;


### PR DESCRIPTION
## Summary

`collectShippingRates()` calls `requestShippingRates()` and has always cleared `shipping_method` whenever `$found` is false. But `$found` has two distinct meanings that are conflated:

1. **No carriers responded at all** — address is genuinely unserviceable → correct to clear
2. **Carriers responded but none matched the currently selected method code** → incorrect to clear

Clearing on case 2 silently wipes `shipping_method` and writes NULL to `quote_address` in the database, causing `placeOrder()` to fail with _"The shipping method is missing. Select the shipping method and try again."_

## Root cause

`requestShippingRates()` docblock already documents the true semantics:
> Returns true if current selected shipping method code corresponds to one of the found rates

The clearing on `!$found` is therefore wrong for the case where rates exist but none match. `ShippingMethodValidationRule::validate()` runs at `placeOrder` time and is the correct place to catch a stale/invalid method selection.

## Trigger

This manifests reliably with carriers that return non-deterministic rate codes (e.g. ShipperHQ, which encodes carrier group identifiers in rate codes). If the address passed to the carrier during `estimate-shipping-methods` differs from the address passed during a subsequent `collectShippingRates()` call — even by leading/trailing whitespace — the carrier may assign a different carrier group and produce a different rate code suffix. The previously selected code no longer matches → `found = false` → method cleared → order fails.

Also triggers when `collectShippingRates()` is called at order-placement time in custom checkout flows (e.g. Loki Checkout's `FinalStep::submit()`) where no carrier session context exists and carriers return no rates at all — same `found = false` outcome.

## Fix

```php
$found = $this->requestShippingRates();
if (!$found) {
    $this->setShippingAmount(0)->setBaseShippingAmount(0);
    if (!$this->getShippingRatesCollection()->getSize()) {
        $this->setShippingMethod('')->setShippingDescription('');
    }
}
```

- Always zero shipping amounts when selected method not found in results (preserved)
- Only clear `shipping_method` and `shipping_description` when the collection is empty — i.e. address is genuinely unserviceable
- Leave `shipping_method` intact when rates exist but none matched — validation at `placeOrder` handles this correctly

## History

This code is **unchanged since `magento/magento2` 2.0.0** (November 2015). It has never been reported or fixed upstream. Standard carriers with stable rate codes never trigger it; dynamic-code carriers expose it consistently.

Fixes #238