### PR TITLE
Restore DHL REST carrier constants lost in merge

### DIFF
--- a/app/code/Magento/Dhl/Model/Carrier.php
+++ b/app/code/Magento/Dhl/Model/Carrier.php
@@ -121,6 +121,32 @@ class Carrier extends AbstractDhl implements CarrierInterface
     public const DHL_REST_API_VERSION = '2.12.0';
 
     /**
+     * DHL API type codes
+     */
+    public const SHIPPER = 'shipper';
+    public const ALL_VALUE_ADDED_SERVICES = 'allValueAddedServices';
+
+    /**
+     * DHL package type - 3BX stands for "Box" (standard DHL box packaging)
+     */
+    public const PACKAGE_TYPE_3BX = '3BX';
+
+    /**
+     * Unit of measurement for quantity
+     */
+    public const UNIT_OF_MEASUREMENT_PCS = 'PCS';
+
+    /**
+     * Delivered At Place
+     */
+    public const INCOTERM_DAP = 'DAP';
+
+    /**
+     * Value‑added service code for Insurance
+     */
+    public const SERVICES_CODE_I_I = 'II';
+
+    /**
      * Rate request data
      *
      * @var RateRequest|null


### PR DESCRIPTION
## Summary

The 2.4.8-p4 merge dropped six `public const` declarations from `Magento\Dhl\Model\Carrier` during conflict resolution while keeping the call sites that reference them. Any DHL REST quote/label request currently fatals at runtime with `Error: Undefined constant Magento\Dhl\Model\Carrier::SHIPPER` (and friends), affecting every store configured with `carriers/dhl/type = DHL_REST`.

Restores the constants from upstream 2.4.8-p4 (`17df7bf7726`), inserted directly after `DHL_REST_API_VERSION`:

- `SHIPPER` — referenced at line 1451
- `ALL_VALUE_ADDED_SERVICES` — referenced at line 1459
- `PACKAGE_TYPE_3BX` — referenced at line 1465
- `INCOTERM_DAP` — referenced at line 1997
- `UNIT_OF_MEASUREMENT_PCS` — referenced at line 2936
- `SERVICES_CODE_I_I` — paired with the rest upstream; included for parity (no current internal reference but may be used by third-party overrides)

## Test plan

- [ ] `grep -nE "self::(SHIPPER|INCOTERM_DAP|UNIT_OF_MEASUREMENT_PCS|PACKAGE_TYPE_3BX|ALL_VALUE_ADDED_SERVICES)" app/code/Magento/Dhl/Model/Carrier.php` resolves all references
- [ ] Re-run `Magento\Dhl\Model\CarrierTest` REST-typed cases (was failing in integration run 25952624578)
- [ ] Place a quote with `carriers/dhl/type = DHL_REST` in a sandbox store — should no longer fatal