### PR TITLE
Guard Csp HashResolver against unresolved area code

### DIFF
--- a/app/code/Magento/Csp/Model/SubresourceIntegrity/HashResolver/HashResolver.php
+++ b/app/code/Magento/Csp/Model/SubresourceIntegrity/HashResolver/HashResolver.php
@@ -267,6 +267,9 @@ class HashResolver implements HashResolverInterface
 
         try {
             $area   = $this->appState->getAreaCode();
+            if (!is_string($area) || $area === '') {
+                return array_unique($contexts);
+            }
             $locale = $this->design->getLocale();
             $theme  = $this->design->getDesignTheme();
 


### PR DESCRIPTION
## Summary

`Magento\Csp\Model\SubresourceIntegrity\HashResolver\HashResolver::buildThemeContextPaths()` is typed `string $area`, but `getContextsToLoad()` reaches it with a value sourced from `State::getAreaCode()`, which can return null in flows where the area has not been initialized (most visibly in mixed-area integration runs). The resulting `TypeError` is swallowed by the outer try/catch in `getContextsToLoad()`, leaving the SRI integrity-hash list silently empty.

This was responsible for 33 errors + 9 failures in the Csp/SubresourceIntegrity integration tests in run [25952624578](https://github.com/mage-os/mageos-magento2/actions/runs/25952624578), plus cascading PaypalGraphQl failures via Csp head-asset plugins.

Adds a 3-line guard at the top of the try block in `getContextsToLoad()`: if `getAreaCode()` returns a non-string or empty value, return only the base contexts (which already tolerate missing area via their own try/catch in `getBaseContexts()`). SRI continues to emit hashes for the base theme; theme/area-specific hashes are skipped instead of crashing the entire resolution.

No upstream Magento p5 fix exists — the entire `SubresourceIntegrity` refactor (commit `898ea36`, AC-16633) is currently Mage-OS-only.

## Test plan

- [ ] Re-run `Magento\Csp\Model\SubresourceIntegrity\*` integration tests; expect green
- [ ] Confirm PaypalGraphQl cascade clears
- [ ] Spot-check `<script integrity="…">` attributes still render on frontend pages

## Follow-up (separate PR)

The reflection workaround at `dev/tests/integration/testsuite/Magento/Csp/Model/SriCustomModuleJsIntegrityTest.php:350-368` becomes unnecessary once this lands.