### PR TITLE
Fix PHPUnit 12 fallout in three integration tests

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Backend/Block/Page/FooterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/Page/FooterTest.php
@@ -30,10 +30,9 @@ class FooterTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $productMetadataMock = $this->getMockBuilder(\Magento\Framework\App\ProductMetadataInterface::class)
-            ->setMethods(['getDistributionName', 'getDistributionVersion'])
+        $productMetadataMock = $this->getMockBuilder(ProductMetadata::class)
             ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+            ->getMock();
         $productMetadataMock->expects($this->once())
             ->method('getDistributionVersion')
             ->willReturn($this::TEST_PRODUCT_VERSION);

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/OptionRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/OptionRepositoryTest.php
@@ -26,9 +26,14 @@ class OptionRepositoryTest extends \PHPUnit\Framework\TestCase
         $joinedEntity->load($options[0]->getId());
         $joinedExtensionAttributeValue = $joinedEntity->getAttributeCode();
         $result = $options[0]->getExtensionAttributes()->__toArray();
+        $this->assertArrayHasKey(
+            'test_dummy_attribute',
+            $result,
+            'Extension attribute "test_dummy_attribute" was not loaded via join processor'
+        );
         $this->assertEquals(
             $joinedExtensionAttributeValue,
-            $result['test_dummy_attribute'],
+            $result['test_dummy_attribute'] ?? null,
             "Extension attributes were not loaded correctly"
         );
     }

--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/PluginListGeneratorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/PluginListGeneratorTest.php
@@ -21,14 +21,16 @@ use PHPUnit\Framework\TestCase;
 class PluginListGeneratorTest extends TestCase
 {
     /**
-     * Generated plugin list config for frontend scope
+     * Generated plugin list config for frontend scope.
+     * Scopes are sorted alphabetically when composing the cache ID — see
+     * PluginListGenerator::write().
      */
-    const CACHE_ID_FRONTEND = 'primary|global|frontend|plugin-list';
+    const CACHE_ID_FRONTEND = 'frontend|global|primary|plugin-list';
 
     /**
-     * Generated plugin list config for dummy scope
+     * Generated plugin list config for dummy scope.
      */
-    const CACHE_ID_DUMMY = 'primary|global|dummy|plugin-list';
+    const CACHE_ID_DUMMY = 'dummy|global|primary|plugin-list';
 
     private $cacheIds = [self::CACHE_ID_FRONTEND, self::CACHE_ID_DUMMY];
 


### PR DESCRIPTION
## Summary

Three unrelated integration tests fail under PHPUnit 12 in the latest release/3.x integration run ([25952624578](https://github.com/mage-os/mageos-magento2/actions/runs/25952624578)). Bundled here because each is a one-to-three-line touch and they share a common root (PHPUnit 12 stricter handling).

### 1. `Backend/Block/Page/FooterTest::testToHtml`

`setMethods()` was removed in PHPUnit 10+. Replace the abstract-interface mock plus method graft with a constructor-disabled mock of the concrete `ProductMetadata` class — both `getDistributionName()` and `getDistributionVersion()` live on `DistributionMetadataInterface`, which the concrete implements. This matches the pattern established in commit `106982bc15a`.

### 2. `ConfigurableProduct/Model/OptionRepositoryTest::testGetListWithExtensionAttributes`

The test's `extension_attributes.xml` join is fragile (joins `product_super_attribute_id` to `eav_attribute.attribute_id`). When the join silently returns no row, `__toArray()` does not include `test_dummy_attribute`. PHPUnit 12 promotes the previously-silent undefined-key warning to an error.

Add an `assertArrayHasKey` guard with a clear failure message, then use `?? null` on the subsequent value lookup so the test produces an intentional assertion failure rather than a warning-as-error if the join breaks.

### 3. `Framework/Interception/PluginListGeneratorTest::testPluginListConfigGeneration`

Commit `7bbee1b6d44` changed `PluginListGenerator::write()` to sort scopes alphabetically before composing the cache ID. The test constants still expect insertion order, so `load()` returns `[]` and every subsequent indexed access trips a warning-as-error.

Updated:
- `CACHE_ID_FRONTEND`: `frontend|global|primary|plugin-list`
- `CACHE_ID_DUMMY`:    `dummy|global|primary|plugin-list`

(`scopePriorityScheme` pops back to `['primary', 'global']` at the end of each iteration when `count > 2`, so `frontend` is not present when `dummy` composes its ID.)

## Test plan

- [ ] `vendor/bin/phpunit -c dev/tests/integration --filter testToHtml dev/tests/integration/testsuite/Magento/Backend/Block/Page/FooterTest.php`
- [ ] `vendor/bin/phpunit -c dev/tests/integration --filter testGetListWithExtensionAttributes dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/OptionRepositoryTest.php`
- [ ] `vendor/bin/phpunit -c dev/tests/integration --filter testPluginListConfigGeneration dev/tests/integration/testsuite/Magento/Framework/Interception/PluginListGeneratorTest.php`