### PR TITLE
Fix DHL CarrierTest fixture SoftwareName to match emitted value

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Dhl/_files/domestic_shipment_request.xml
+++ b/dev/tests/integration/testsuite/Magento/Dhl/_files/domestic_shipment_request.xml
@@ -15,7 +15,7 @@
             <Password>some password</Password>
         </ServiceHeader>
         <MetaData>
-            <SoftwareName>Mage-OS</SoftwareName>
+            <SoftwareName>Magento</SoftwareName>
             <SoftwareVersion>1.0.0+no-v</SoftwareVersion>
         </MetaData>
     </Request>

--- a/dev/tests/integration/testsuite/Magento/Dhl/_files/shipment_request.xml
+++ b/dev/tests/integration/testsuite/Magento/Dhl/_files/shipment_request.xml
@@ -15,7 +15,7 @@
             <Password>some password</Password>
         </ServiceHeader>
         <MetaData>
-            <SoftwareName>Mage-OS</SoftwareName>
+            <SoftwareName>Magento</SoftwareName>
             <SoftwareVersion>1.0.0+no-v</SoftwareVersion>
         </MetaData>
     </Request>


### PR DESCRIPTION
## Summary
- `dev/tests/integration/testsuite/Magento/Dhl/Model/CarrierTest::testRequestToShip` failed on all four data variants in [run 25978664094](https://github.com/mage-os/mageos-magento2/actions/runs/25978664094/job/76363369369) with `<SoftwareName>` mismatching the fixture:
  ```
  - <SoftwareName>Mage-OS</SoftwareName>
  + <SoftwareName>Magento</SoftwareName>
  ```
- `Carrier::buildSoftwareName()` returns `productMetadata->getName()`, which is the hardcoded `ProductMetadata::PRODUCT_NAME = 'Magento'` constant. The fixture was changed to `Mage-OS` in PR #61 back in 2024, but the carrier code was never updated to emit a Mage-OS value (and the `PRODUCT_NAME` constant in `ProductMetadata` is unchanged from upstream). The fixture has been wrong ever since — masked previously by whatever else was failing in the DHL shard.
- Revert the two fixture files (`_files/domestic_shipment_request.xml`, `_files/shipment_request.xml`) to the value the carrier actually emits.

## Open question (separate decision)
If Mage-OS wants DHL request `SoftwareName` to identify the distribution rather than the upstream product, the right place is `Carrier::buildSoftwareName()` emitting `DISTRIBUTION_NAME` (`Mage-OS`) — and the fixtures would be updated to match. Filing this as a small, low-risk revert so the 3.0 build is green; the branding question can be picked up independently.

## Test plan
- [ ] Re-run the `Magento/Dhl` shard of the full integration tests and confirm all four `testRequestToShip` data variants pass.
- [ ] Verify no other fixture in `dev/tests/integration/testsuite/Magento/Dhl/_files/` still references `Mage-OS` as `SoftwareName` (greps clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)