### PR TITLE
Fix unit test fallout from post-merge optional constructor deps

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart.php
+++ b/app/code/Magento/Checkout/Block/Cart.php
@@ -39,6 +39,7 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
      * @param \Magento\Checkout\Helper\Cart $cartHelper
      * @param \Magento\Framework\App\Http\Context $httpContext
      * @param array $data
+     * @param \Magento\Framework\App\CacheInterface|null $cache
      * @codeCoverageIgnore
      */
     public function __construct(
@@ -48,11 +49,12 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
         \Magento\Catalog\Model\ResourceModel\Url $catalogUrlBuilder,
         \Magento\Checkout\Helper\Cart $cartHelper,
         \Magento\Framework\App\Http\Context $httpContext,
-        array $data = []
+        array $data = [],
+        ?\Magento\Framework\App\CacheInterface $cache = null
     ) {
         $this->_cartHelper = $cartHelper;
         $this->_catalogUrlBuilder = $catalogUrlBuilder;
-        parent::__construct($context, $customerSession, $checkoutSession, $data);
+        parent::__construct($context, $customerSession, $checkoutSession, $data, $cache);
         $this->_isScopePrivate = true;
         $this->httpContext = $httpContext;
     }

--- a/app/code/Magento/Checkout/Block/Cart/Grid.php
+++ b/app/code/Magento/Checkout/Block/Cart/Grid.php
@@ -56,6 +56,7 @@ class Grid extends \Magento\Checkout\Block\Cart
      * @param \Magento\Quote\Model\ResourceModel\Quote\Item\CollectionFactory $itemCollectionFactory
      * @param \Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface $joinProcessor
      * @param array $data
+     * @param \Magento\Framework\App\CacheInterface|null $cache
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
@@ -66,7 +67,8 @@ class Grid extends \Magento\Checkout\Block\Cart
         \Magento\Framework\App\Http\Context $httpContext,
         \Magento\Quote\Model\ResourceModel\Quote\Item\CollectionFactory $itemCollectionFactory,
         \Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface $joinProcessor,
-        array $data = []
+        array $data = [],
+        ?\Magento\Framework\App\CacheInterface $cache = null
     ) {
         $this->itemCollectionFactory = $itemCollectionFactory;
         $this->joinAttributeProcessor = $joinProcessor;
@@ -77,7 +79,8 @@ class Grid extends \Magento\Checkout\Block\Cart
             $catalogUrlBuilder,
             $cartHelper,
             $httpContext,
-            $data
+            $data,
+            $cache
         );
     }
 

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/GridTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/GridTest.php
@@ -10,6 +10,7 @@ namespace Magento\Checkout\Test\Unit\Block\Cart;
 use Magento\Checkout\Block\Cart\Grid;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
+use Magento\Framework\App\CacheInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Framework\View\LayoutInterface;
@@ -75,6 +76,11 @@ class GridTest extends TestCase
     private $pagerBlockMock;
 
     /**
+     * @var MockObject
+     */
+    private $cacheMock;
+
+    /**
      * @inheritDoc
      */
     protected function setUp(): void
@@ -101,6 +107,7 @@ class GridTest extends TestCase
         $this->pagerBlockMock = $this->getMockBuilder(Pager::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->cacheMock = $this->createMock(CacheInterface::class);
         $this->checkoutSessionMock->method('getQuote')->willReturn($this->quoteMock);
         $this->quoteMock->method('getAllVisibleItems')->willReturn([]);
         $this->block = $objectManagerHelper->getObject(
@@ -111,6 +118,7 @@ class GridTest extends TestCase
                 'scopeConfig' => $this->scopeConfigMock,
                 'checkoutSession' => $this->checkoutSessionMock,
                 'layout' => $this->layoutMock,
+                'cache' => $this->cacheMock,
                 'data' => ['template' => 'cart/form1.phtml']
             ]
         );
@@ -222,6 +230,7 @@ class GridTest extends TestCase
                 'scopeConfig' => $this->scopeConfigMock,
                 'checkoutSession' => $this->checkoutSessionMock,
                 'layout' => $this->layoutMock,
+                'cache' => $this->cacheMock,
                 'data' => ['custom_items' => [$itemMock]],
                 'storeManager' => $storeManager
             ]

--- a/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
@@ -10,6 +10,7 @@ namespace Magento\ConfigurableImportExport\Model\Import\Product\Type;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\CatalogImportExport\Model\Import\Product as ImportProduct;
 use Magento\CatalogImportExport\Model\Import\Product\SkuStorage;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory as AttributeOptionCollectionFactory;
 use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Framework\Exception\LocalizedException;
 
@@ -219,6 +220,7 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
      * @param \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $_productColFac
      * @param MetadataPool $metadataPool
      * @param SkuStorage $skuStorage
+     * @param AttributeOptionCollectionFactory|null $attributeOptionCollectionFactory
      */
     public function __construct(
         \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\CollectionFactory $attrSetColFac,
@@ -229,9 +231,17 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
         \Magento\ImportExport\Model\ResourceModel\Helper $resourceHelper,
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $_productColFac,
         ?MetadataPool $metadataPool = null,
-        ?SkuStorage $skuStorage = null
+        ?SkuStorage $skuStorage = null,
+        ?AttributeOptionCollectionFactory $attributeOptionCollectionFactory = null
     ) {
-        parent::__construct($attrSetColFac, $prodAttrColFac, $resource, $params, $metadataPool);
+        parent::__construct(
+            $attrSetColFac,
+            $prodAttrColFac,
+            $resource,
+            $params,
+            $metadataPool,
+            $attributeOptionCollectionFactory
+        );
         $this->_productTypesConfig = $productTypesConfig;
         $this->_resourceHelper = $resourceHelper;
         $this->_productColFac = $_productColFac;

--- a/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Export/RowCustomizerTest.php
+++ b/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Export/RowCustomizerTest.php
@@ -13,6 +13,7 @@ use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\CatalogImportExport\Model\Import\Product as ImportProduct;
 use Magento\ConfigurableImportExport\Model\Export\RowCustomizer as ExportRowCustomizer;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProductType;
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\ImportExport\Model\Import;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -176,33 +177,20 @@ class RowCustomizerTest extends TestCase
         $productIds = [1, 2, 3];
         $expectedConfigurableData = $this->getExpectedConfigurableData();
         $productMock = $this->createProductMock();
-        $productAttributesOptions = [
-            [
-                [
-                    'pricing_is_percent'    => true,
-                    'sku'                   => '_sku_',
-                    'attribute_code'        => 'code_of_attribute',
-                    'option_title'          => 'Option Title',
-                    'pricing_value'         => 112345,
-                    'super_attribute_label' => 'Super attribute label'
-                ],
-                [
-                    'pricing_is_percent'    => false,
-                    'sku'                   => '_sku_',
-                    'attribute_code'        => 'code_of_attribute',
-                    'option_title'          => 'Option Title',
-                    'pricing_value'         => 212345,
-                    'super_attribute_label' => ''
-                ],
-                [
-                    'pricing_is_percent'    => false,
-                    'sku'                   => '_sku_2',
-                    'attribute_code'        => 'code_of_attribute_2',
-                    'option_title'          => 'Option Title 2',
-                    'pricing_value'         => 312345,
-                    'super_attribute_label' => 'Super attribute label 2'
-                ]
-            ]
+
+        $superAttributes = [
+            $this->createSuperAttributeMock('code_of_attribute', 'Super attribute label'),
+            $this->createSuperAttributeMock('code_of_attribute_2', 'Super attribute label 2')
+        ];
+        $childProducts = [
+            $this->createChildProductMock(
+                '_sku_',
+                ['code_of_attribute' => 'Option Title', 'code_of_attribute_2' => 'Option Title 2']
+            ),
+            $this->createChildProductMock(
+                '_sku_2',
+                ['code_of_attribute' => 'Option Title A', 'code_of_attribute_2' => 'Option Title B']
+            )
         ];
 
         $productMock->expects(static::any())
@@ -212,8 +200,13 @@ class RowCustomizerTest extends TestCase
             ->method('getTypeInstance')
             ->willReturn($this->configurableProductTypeMock);
         $this->configurableProductTypeMock->expects(static::any())
-            ->method('getConfigurableOptions')
-            ->willReturn($productAttributesOptions);
+            ->method('getUsedProductAttributes')
+            ->with($productMock)
+            ->willReturn($superAttributes);
+        $this->configurableProductTypeMock->expects(static::any())
+            ->method('getUsedProducts')
+            ->with($productMock)
+            ->willReturn($childProducts);
         $this->productCollectionMock->expects(static::atLeastOnce())
             ->method('addAttributeToFilter')
             ->willReturnMap(
@@ -234,6 +227,35 @@ class RowCustomizerTest extends TestCase
     }
 
     /**
+     * @param string $code
+     * @param string $label
+     * @return AbstractAttribute|MockObject
+     */
+    private function createSuperAttributeMock(string $code, string $label)
+    {
+        $attribute = $this->createMock(AbstractAttribute::class);
+        $attribute->method('getAttributeCode')->willReturn($code);
+        $attribute->method('getDefaultFrontendLabel')->willReturn($label);
+        return $attribute;
+    }
+
+    /**
+     * @param string $sku
+     * @param array<string, string> $attributeTextMap
+     * @return Product|MockObject
+     */
+    private function createChildProductMock(string $sku, array $attributeTextMap)
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getSku')->willReturn($sku);
+        $product->method('getAttributeText')
+            ->willReturnCallback(
+                static fn (string $code): string => $attributeTextMap[$code] ?? ''
+            );
+        return $product;
+    }
+
+    /**
      * Return expected configurable data
      *
      * @return array
@@ -248,12 +270,12 @@ class RowCustomizerTest extends TestCase
                         '_sku_' => 'sku=_sku_' . Import::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR
                             . implode(
                                 Import::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR,
-                                ['code_of_attribute=Option Title', 'code_of_attribute=Option Title']
+                                ['code_of_attribute=Option Title', 'code_of_attribute_2=Option Title 2']
                             ),
                         '_sku_2' => 'sku=_sku_2' . Import::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR
                             . implode(
                                 Import::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR,
-                                ['code_of_attribute_2=Option Title 2']
+                                ['code_of_attribute=Option Title A', 'code_of_attribute_2=Option Title B']
                             )
                     ]
                 ),

--- a/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
@@ -16,6 +16,7 @@ use Magento\CatalogImportExport\Model\Import\Product;
 use Magento\ConfigurableImportExport;
 use Magento\ConfigurableImportExport\Model\Import\Product\Type\Configurable;
 use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory as AttributeOptionCollectionFactory;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DataObject;
@@ -298,6 +299,7 @@ class ConfigurableTest extends AbstractImportTestCase
 
         $productTypesConfig = $this->createMock(ConfigInterface::class);
         $resourceHelper = $this->createMock(\Magento\ImportExport\Model\ResourceModel\Helper::class);
+        $attributeOptionCollectionFactory = $this->createMock(AttributeOptionCollectionFactory::class);
 
         $this->configurable = $this->objectManagerHelper->getObject(
             Configurable::class,
@@ -310,7 +312,8 @@ class ConfigurableTest extends AbstractImportTestCase
                 'resourceHelper' => $resourceHelper,
                 'productColFac' => $this->productCollectionFactory,
                 'metadataPool' => $metadataPoolMock,
-                'skuStorage' => $this->skuStorage
+                'skuStorage' => $this->skuStorage,
+                'attributeOptionCollectionFactory' => $attributeOptionCollectionFactory
             ]
         );
     }


### PR DESCRIPTION
## Summary

Two recent upstream merges added optional constructor params that lazy-fetch via `ObjectManager::getInstance()` when null:

- `AbstractCart::__construct` — `?CacheInterface $cache = null`
- `AbstractType::__construct` (CatalogImportExport) — `?AttributeOptionCollectionFactory $attributeOptionCollectionFactory = null`

Their subclasses didn't forward the new args to `parent::__construct`, so when unit tests built these objects via `ObjectManagerHelper::getObject()`, the fallback fired and threw `RuntimeException: ObjectManager isn't initialized`.

This caused 15 failures across 3 test classes on PHP 8.3 Unit Tests CI (run `25980461893`).

## Changes

### Production (forward optional dep to parent — BC-safe, mirrors `Downloadable::__construct`)
- `app/code/Magento/Checkout/Block/Cart.php` — accept and forward `?CacheInterface $cache`
- `app/code/Magento/Checkout/Block/Cart/Grid.php` — accept and forward `?CacheInterface $cache`
- `app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php` — accept and forward `?AttributeOptionCollectionFactory $attributeOptionCollectionFactory`

### Tests (inject new mocks)
- `app/code/Magento/Checkout/Test/Unit/Block/Cart/GridTest.php` — inject `CacheInterface` mock
- `app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php` — inject `AttributeOptionCollectionFactory` mock
- `app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Export/RowCustomizerTest.php` — rewrite `initConfigurableData()` fixture and `getExpectedConfigurableData()` to match the new `prepareData()` algorithm, which uses `getUsedProductAttributes`/`getUsedProducts` instead of `getConfigurableOptions` (refactored in 56635a6b81a, October 2025; test was missed at the time)

## Backward compatibility

All production changes add a new optional last parameter to the constructor and forward it to `parent::__construct`. Existing callers continue to work unchanged (the lazy ObjectManager fallback still fires for any caller that doesn't supply the new arg). No public API is removed or renamed.

## Test plan

- [x] `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Checkout/Test/Unit` → 284 tests, 0 errors
- [x] `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/ConfigurableImportExport/Test/Unit` → 9 tests, 0 errors
- [x] `vendor/bin/phpcs --standard=Magento2` on the 6 modified files → 0 errors
- [ ] CI Unit Tests on `release/3.x` green