### PR TITLE
Align integration test matrix with Magento 2.4.9 certified services

### DIFF
--- a/supported-services.json
+++ b/supported-services.json
@@ -7,19 +7,19 @@
             2
         ],
         "database": [
-            "mariadb:11.4"
+            "mariadb:11.8"
         ],
         "search": [
-          "opensearch:2.17"
+          "opensearch:3"
         ],
         "message_queue": [
-            "rabbitmq:4.0"
+            "rabbitmq:4.2"
         ],
         "cache": [
             "redis:7.4"
         ],
         "http_cache": [
-            "varnish:7.6"
+            "varnish:8"
         ]
     }
 }

--- a/supported-services.json
+++ b/supported-services.json
@@ -1,7 +1,7 @@
 {
     "services": {
         "php": [
-            8.3
+            8.4
         ],
         "composer": [
             2


### PR DESCRIPTION
## Summary

Align `supported-services.json` with Adobe's certified service matrix for Magento Open Source / Adobe Commerce 2.4.9 ([on-prem system requirements](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements)).

| Service | Before | After | 2.4.9 cert |
|---|---|---|---|
| PHP | 8.3 | **8.4** | 8.5 |
| MariaDB | 11.4 | **11.8** | 11.8 (12.3 pending GA) |
| OpenSearch | 2.17 | **3** | 3 |
| RabbitMQ | 4.0 | **4.2** | 4.2 |
| Varnish | 7.6 | **8** | 8 |
| Redis | 7.4 | 7.4 (unchanged) | not supported — replaced by Valkey 9 |

Matrix dimensions are unchanged, so job count is the same.

## Why

PHP 8.3 is no longer the freshest line in our `~8.3.0||~8.4.0||~8.5.0` composer constraints, and the database / search / MQ / HTTP-cache values were still on the 2.4.8 matrix. Running CI on the 2.4.9 certified versions catches forward-compat issues before they bite the 3.0 cut.

## Out of scope (follow-up work)

- **PHP 8.5**: in the composer constraints and supported by `shivammathur/setup-php@v2`, but warrants a scoped smoke run before flipping the full suite.
- **Valkey 9 / MySQL 8.4**: `mage-os/github-actions`' `warden/setup-environment` action exposes `redis:` and `database:` (MariaDB-branch only) inputs. Adding Valkey/MySQL needs upstream action changes first.

## Test plan

- [ ] Trigger `Integration Tests - Full Test Suite` workflow on this branch via `workflow_dispatch`.
- [ ] Confirm the matrix calculator emits the bumped versions and Warden boots them.
- [ ] Verify `opensearch:3` and `varnish:8` are tags the Warden docker-compose template accepts — if either fails, fall back to the latest accepted tag and document.
- [ ] Compare pass/fail totals to the last 2.4.8 matrix run on `release/3.x` (currently 9 errors + 20 failures in `Magento/Csp`, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
