### PR TITLE
Pin opensearch and varnish to existing wardenenv image tags

### DIFF
--- a/supported-services.json
+++ b/supported-services.json
@@ -10,7 +10,7 @@
             "mariadb:11.8"
         ],
         "search": [
-          "opensearch:3"
+          "opensearch:3.4"
         ],
         "message_queue": [
             "rabbitmq:4.2"
@@ -19,7 +19,7 @@
             "redis:7.4"
         ],
         "http_cache": [
-            "varnish:8"
+            "varnish:8.0"
         ]
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #246. `wardenenv` publishes `opensearch` and `varnish` images with `major.minor` tags only — the bare-major tags `opensearch:3` and `varnish:8` shipped in #246 don't exist on Docker Hub, so Warden fails to boot with:

```
Error response from daemon: manifest for wardenenv/varnish:8 not found: manifest unknown
```

Pinning to the latest minor under each major:

- `opensearch:3` → `opensearch:3.4`
- `varnish:8` → `varnish:8.0`

(`mariadb:11.8` and `rabbitmq:4.2` already match real wardenenv tags, no change.)

## Test plan

- [ ] Trigger `Integration Tests - Full Test Suite` workflow on this branch via `workflow_dispatch`.
- [ ] Confirm Warden pulls both images successfully and the matrix job advances past `Setup Warden Environment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)