### PR TITLE
fix(Quote/Address): preserve method/amounts when rates exist but codes mismatch

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -1021,7 +1021,10 @@ class Address extends AbstractAddress implements
 
         $found = $this->requestShippingRates();
         if (!$found) {
-            $this->setShippingAmount(0)->setBaseShippingAmount(0)->setShippingMethod('')->setShippingDescription('');
+            if (empty($this->getAllShippingRates())) {
+                $this->setShippingAmount(0)->setBaseShippingAmount(0)
+                    ->setShippingMethod('')->setShippingDescription('');
+            }
         }
 
         return $this;


### PR DESCRIPTION
## Problem

`collectShippingRates()` unconditionally clears `shipping_method` and `shipping_amount` whenever the selected rate code is not found in the newly-collected results. This is too aggressive.

Carriers like ShipperHQ use dynamic rate codes containing carrier-group identifiers that can differ between the `estimate-shipping-methods` call (using the browser-submitted address) and the server-side collection triggered by `setShippingInformation` (which may trim or normalise address fields on save). The method is still valid — only the code format changed — but the original code treats this as a missing rate and clears the selection.

## Root cause

`Address::collectShippingRates()` at the `!$found` branch:

```php
// original
$this->setShippingAmount(0)->setBaseShippingAmount(0)->setShippingMethod('')->setShippingDescription('');
```

`$found` means "the previously-selected code was present in the newly-collected rates" — not "any rates were returned." Clearing `shipping_method` when rates exist but none match the stored code is incorrect.

## Why `getShippingRatesCollection()->getSize()` is wrong

A prior attempt guarded the method-clear with `!getShippingRatesCollection()->getSize()`. This is unreliable: `AbstractDb::getSize()` caches `_totalRecords` from a DB COUNT on first access. `removeAllShippingRates()` only soft-deletes `_items` in memory and never updates `_totalRecords`, so on any saved address with prior rates in DB, `getSize()` returns a stale non-zero count and the guard is never triggered.

## Fix

Only clear method/amounts when the collection is genuinely empty (address unserviceable). When rates exist but none match the selected code, preserve all stored values.

```php
$found = $this->requestShippingRates();
if (!$found) {
    if (empty($this->getAllShippingRates())) {
        $this->setShippingAmount(0)->setBaseShippingAmount(0)
            ->setShippingMethod('')->setShippingDescription('');
    }
    // rates exist but selected code absent: preserve all stored values
}
```

`getAllShippingRates()` iterates `_items` filtering soft-deleted entries — accurate in-memory active rate count.

## Failure modes compared

| Scenario | Original | This fix |
|---|---|---|
| No rates returned (unserviceable address) | Clears method + amounts ✓ | Clears method + amounts ✓ |
| Rates returned, selected code matches | No-op (found=true) ✓ | No-op (found=true) ✓ |
| Rates returned, selected code absent (e.g. ShipperHQ code format diff) | Clears method → "shipping method is missing" ✗ | Preserves method + amounts ✓ |
| Rates returned, code absent, order placed | Hard error at QuoteValidator | Shipping collector finds rate at collectTotals time; genuine mismatches caught earlier by ShippingInformationManagement::getShippingRateByCode() ✓ |

## Related
