### PR TITLE
Detect missing laravel/prompts in interactive installer

### DIFF
--- a/setup/src/MageOS/Installer/Console/Command/InstallCommand.php
+++ b/setup/src/MageOS/Installer/Console/Command/InstallCommand.php
@@ -113,6 +113,21 @@ class InstallCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if (!function_exists('Laravel\\Prompts\\confirm')) {
+            $output->writeln('');
+            $output->writeln(
+                '<error>The interactive installer requires the "laravel/prompts" package, '
+                . 'which is not installed.</error>'
+            );
+            $output->writeln('');
+            $output->writeln(
+                '<comment>Run the following from your project root to install it:</comment>'
+            );
+            $output->writeln('  <info>composer require --dev laravel/prompts</info>');
+            $output->writeln('');
+            return Command::FAILURE;
+        }
+
         try {
             $baseDir = BP; // Magento base directory constant
 


### PR DESCRIPTION
## Summary

- `bin/magento install` (the interactive installer added in #191) fatals with `Call to undefined function Laravel\Prompts\confirm()` on Mage-OS Minimal, which doesn't ship `laravel/prompts` by default.
- Guard `InstallCommand::execute()` so it detects the missing package up-front and exits cleanly with an actionable message: `composer require --dev laravel/prompts`.
- All other `bin/magento` commands are unaffected — the check runs only when `install` is invoked.

## Test plan

- [x] Reproduced original fatal on a Mage-OS Minimal 3.0.0 install (trace pointed at `WelcomeStage.php:72` → `Laravel\Prompts\confirm()`).
- [x] After the fix, running `bin/magento install` in the same minimal install prints the friendly error and returns exit code 1, no PHP fatal.
- [ ] Verify on a normal Mage-OS install that `bin/magento install` still launches the wizard unchanged.
- [ ] Verify `bin/magento list` / `--help` still work in the missing-package state (guard is scoped to the `install` command's `execute()` only).