### PR TITLE
Fix getShippingAddressId() typo in Sales Order PHPDoc

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -67,7 +67,7 @@ use Magento\Store\Model\StoreManagerInterface;
  * @method Order unsBillingAddressId()
  * @method bool hasShippingAddressId()
  * @method Order unsShippingAddressId()
- * @method int getShippigAddressId()
+ * @method int getShippingAddressId()
  * @method bool hasCustomerNoteNotify()
  * @method bool hasForcedCanCreditmemo()
  * @method bool getIsInProcess()


### PR DESCRIPTION
### Description

Fixes a typo in the `@method` PHPDoc annotation on `\Magento\Sales\Model\Order`. The method was declared as `getShippigAddressId()` (missing the second `p` in "Shipping"), causing IDEs and static analysis tools to generate incorrect method stubs.

### Related Pull Requests

None.

### Fixed Issues

1. Fixes mage-os/mageos-magento2#254

### Manual testing scenarios

No runtime behaviour changes — PHPDoc annotation only.

1. Open `app/code/Magento/Sales/Model/Order.php` in an IDE with PHP intelligence (PhpStorm / Intelephense)
2. Confirm autocomplete now suggests `getShippingAddressId()` correctly
3. Run static analysis: `vendor/bin/phpstan analyse app/code/Magento/Sales/Model/Order.php` — no errors related to this method

### Questions or comments

This is a one-character fix. No unit test is applicable — `@method` annotations are not executable code and have no test coverage path.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable) — N/A, PHPDoc only
- [ ] README.md files for modified modules are updated and included in the pull request if any predefined sections require an update — N/A
- [x] All automated tests passed successfully (all builds are green)