### PR TITLE
Fix max_text_length validator incorrectly failing on undefined values

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -124,7 +124,7 @@ define([
         ],
         'max_text_length': [
             function (value, params) {
-                return !_.isUndefined(value) && value.length <= +params;
+                return _.isUndefined(value) || value.length <= +params;
             },
             $.mage.__('Please enter less or equal than {0} symbols.')
         ],

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/lib/validation/rules.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/lib/validation/rules.test.js
@@ -10,6 +10,28 @@ define([
     'use strict';
 
     describe('Magento_Ui/js/lib/validation/rules', function () {
+        describe('"max_text_length" method', function () {
+            it('passes when value is undefined', function () {
+                expect(rules['max_text_length'].handler(undefined, 10)).toBe(true);
+            });
+
+            it('passes when value is empty string', function () {
+                expect(rules['max_text_length'].handler('', 10)).toBe(true);
+            });
+
+            it('passes when value length equals the limit', function () {
+                expect(rules['max_text_length'].handler('hello', 5)).toBe(true);
+            });
+
+            it('passes when value length is within the limit', function () {
+                expect(rules['max_text_length'].handler('hi', 10)).toBe(true);
+            });
+
+            it('fails when value length exceeds the limit', function () {
+                expect(rules['max_text_length'].handler('hello world', 5)).toBe(false);
+            });
+        });
+
         describe('"range-words" method', function () {
             it('Check on empty value', function () {
                 var value = '',


### PR DESCRIPTION
### Description

The `max_text_length` handler in `rules.js` used `!_.isUndefined(value) &&` which causes it to return `false` when value is `undefined`. The correct pattern — already used by the sibling `min_text_length` rule in the same file — is `_.isUndefined(value) ||`, which lets undefined values pass through.

### Related Pull Requests

None.

### Fixed Issues

1. Fixes mage-os/mageos-magento2#256

### Manual testing scenarios

Open any admin page, open the browser DevTools console, and run:

```javascript
require(['Magento_Ui/js/lib/validation/rules'], function(rules) {
    console.log('max_text_length(undefined):', rules['max_text_length'].handler(undefined, 10));
    console.log('min_text_length(undefined):', rules['min_text_length'].handler(undefined, 1));
});
```

**Before fix:**
```
max_text_length(undefined): false  ← incorrect
min_text_length(undefined): true
```

**After fix:**
```
max_text_length(undefined): true   ← correct
min_text_length(undefined): true
```

### Jasmine test results

A `max_text_length` describe block has been added to the existing `rules.test.js`. The suite was run locally via `grunt spec:blank --file=...` against a deployed Magento/blank theme:

```
Magento_Ui/js/lib/validation/rules
  "max_text_length" method
    - passes when value is undefined......✓
    - passes when value is empty string......✓
    - passes when value length equals the limit......✓
    - passes when value length is within the limit......✓
    - fails when value length exceeds the limit......✓
  "range-words" method
    ...
38 specs in 0.027s.
>> 0 failures
```

> **Note:** The Jasmine test infrastructure (`grunt spec`) is not currently wired into any CI workflow. Tests were verified manually. Results are posted here so reviewers can confirm coverage without needing to run the suite locally.

### Questions or comments

The bug is masked in the standard UI component form flow because `abstract.js::normaliseData()` converts `undefined` → `''` before validation runs. The handler is part of the public `rules` API however, and the inconsistency with `min_text_length` is clearly unintentional.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable) — Jasmine tests added to `rules.test.js`; results posted above as CI does not run the JS test suite
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (PHP CI green; JS verified locally)