### PR TITLE
Convert admin forgot-password email to HTML with clickable reset link

### DIFF
--- a/app/code/Magento/User/etc/email_templates.xml
+++ b/app/code/Magento/User/etc/email_templates.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Email:etc/email_templates.xsd">
-    <template id="admin_emails_forgot_email_template" label="Forgot Admin Password" file="password_reset_confirmation.html" type="text" module="Magento_User" area="adminhtml"/>
+    <template id="admin_emails_forgot_email_template" label="Forgot Admin Password" file="password_reset_confirmation.html" type="html" module="Magento_User" area="adminhtml"/>
     <template id="admin_emails_user_notification_template" label="User Notification" file="user_notification.html" type="text" module="Magento_User" area="adminhtml"/>
     <template id="admin_emails_new_user_notification_template"
               label="New User Notification"

--- a/app/code/Magento/User/view/adminhtml/email/password_reset_confirmation.html
+++ b/app/code/Magento/User/view/adminhtml/email/password_reset_confirmation.html
@@ -14,15 +14,13 @@
 "var username":"Account Holder Name"
 } @-->
 
-{{trans "%name," name=$username}}
+<p>{{trans "%name," name=$username}}</p>
 
-{{trans "There was recently a request to change the password for your account."}}
+<p>{{trans "There was recently a request to change the password for your account."}}</p>
 
-{{trans "If you requested this change, reset your password here:"}}
+<p>{{trans "If you requested this change, reset your password here:"}}<br>
+<a href="{{store url='admin/auth/resetpassword/' _type='web' _query_id=$user.user_id _query_token=$user.rp_token _nosid=1}}">{{trans "Reset Password"}}</a></p>
 
-{{store url="admin/auth/resetpassword/" _type="web" _query_id=$user.user_id _query_token=$user.rp_token _nosid=1 }}
+<p>{{trans "If you did not make this request, you can ignore this email and your password will remain the same."}}</p>
 
-{{trans "If you did not make this request, you can ignore this email and your password will remain the same."}}
-
-{{trans "Thank you,"}}
-{{var store.frontend_name}}
+<p>{{trans "Thank you,"}}<br>{{var store.frontend_name}}</p>

--- a/app/code/Magento/User/view/adminhtml/email/password_reset_confirmation.html
+++ b/app/code/Magento/User/view/adminhtml/email/password_reset_confirmation.html
@@ -19,7 +19,7 @@
 <p>{{trans "There was recently a request to change the password for your account."}}</p>
 
 <p>{{trans "If you requested this change, reset your password here:"}}<br>
-<a href="{{store url='admin/auth/resetpassword/' _type='web' _query_id=$user.user_id _query_token=$user.rp_token _nosid=1}}">{{trans "Reset Password"}}</a></p>
+<a href="{{store url='admin/auth/resetpassword/' _type='web' _query_id=$user.user_id _query_token=$user.rp_token _nosid=1}}" target="_blank">{{trans "Reset Password"}}</a></p>
 
 <p>{{trans "If you did not make this request, you can ignore this email and your password will remain the same."}}</p>
 


### PR DESCRIPTION
### Description

The admin forgot-password email template was declared `type="text"` in `email_templates.xml`. The reset URL renders as a raw string and wraps across multiple lines on long tokens. In email clients that do not auto-link plain text URLs (Outlook), the link is non-functional.

The customer equivalent (`Magento_Customer::password_reset_confirmation.html`) is already `type="html"` with an anchor link. This aligns the admin template to the same standard.

Changes:
- `email_templates.xml`: `type="text"` → `type="html"` for `admin_emails_forgot_email_template`
- `password_reset_confirmation.html`: wrapped content in `<p>` tags, replaced raw URL with a clickable `<a>` link

### Related Pull Requests

None.

### Fixed Issues

1. Fixes mage-os/mageos-magento2#260

### Manual testing scenarios

1. Go to `<store>/admin/admin/auth/forgotpassword/`
2. Enter an admin email address and submit
3. Check the email in your mail catcher

**Before fix:**
- Email arrives as `Content-Type: text/plain`
- Reset URL is a raw string that wraps across lines on long tokens

**After fix:**
- Email arrives as `Content-Type: text/html; charset=utf-8`
- Body contains a proper `<a href="...">Reset Password</a>` link that works in all email clients

### Questions or comments

The change is intentionally minimal — `<p>` tags and a single anchor link, consistent with the structure of other admin email templates in the module (which use no header/footer directives). A more styled version using the same button table pattern as the customer equivalent is possible but was kept out of scope here.

No unit test exists for this type of change (XML config declaration + HTML template file). The fix was verified manually via Mailpit confirming `Content-Type: text/html` in the outgoing email headers.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable) — no test infrastructure exists for email template type declarations; fix verified manually
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (PHP CI green)