### PR TITLE
Fix QueryParamsResolver corrupting base64 values and crashing on valueless params

### DIFF
--- a/lib/internal/Magento/Framework/Url/QueryParamsResolver.php
+++ b/lib/internal/Magento/Framework/Url/QueryParamsResolver.php
@@ -63,9 +63,12 @@ class QueryParamsResolver extends \Magento\Framework\DataObject implements
         if (!$this->hasData('query_params')) {
             $params = [];
             if ($this->_getData('query')) {
-                foreach (explode('&', $this->_getData('query')) as $param) {
-                    $paramArr = explode('=', $param);
-                    $params[$paramArr[0]] = urldecode($paramArr[1]);
+                foreach (explode('&', (string)$this->_getData('query')) as $param) {
+                    if ($param === '') {
+                        continue;
+                    }
+                    $paramArr = explode('=', $param, 2);
+                    $params[$paramArr[0]] = urldecode($paramArr[1] ?? '');
                 }
             }
             $this->setData('query_params', $params);

--- a/lib/internal/Magento/Framework/Url/Test/Unit/QueryParamsResolverTest.php
+++ b/lib/internal/Magento/Framework/Url/Test/Unit/QueryParamsResolverTest.php
@@ -66,4 +66,29 @@ class QueryParamsResolverTest extends TestCase
         $this->object->addQueryParams(['foo' => 'bar', 'true' => 'false']);
         $this->assertEquals(['foo' => 'bar', 'true' => 'false'], $this->object->getQueryParams());
     }
+
+    public function testGetQueryParamsWithValuelessParam()
+    {
+        $this->object->setQuery('foo&bar=1');
+        $params = $this->object->getQueryParams();
+        $this->assertArrayHasKey('foo', $params);
+        $this->assertSame('', $params['foo']);
+        $this->assertSame('1', $params['bar']);
+    }
+
+    public function testGetQueryParamsPreservesEqualsInValue()
+    {
+        $this->object->setQuery('token=abc==&other=val');
+        $params = $this->object->getQueryParams();
+        $this->assertSame('abc==', $params['token']);
+        $this->assertSame('val', $params['other']);
+    }
+
+    public function testGetQueryParamsIgnoresTrailingAmpersand()
+    {
+        $this->object->setQuery('foo=bar&');
+        $params = $this->object->getQueryParams();
+        $this->assertArrayNotHasKey('', $params);
+        $this->assertSame('bar', $params['foo']);
+    }
 }


### PR DESCRIPTION
### Description

`QueryParamsResolver::getQueryParams()` used `explode('=', $param)` with no limit to parse query string parameters. This caused three defects:

1. **Valueless params** (`?foo&bar=1`) — `$paramArr[1]` was undefined, producing a PHP 8.x warning
2. **Values containing `=`** (`?token=abc==`) — truncated at the first extra `=`, silently corrupting base64-padded tokens, API keys, and OAuth state params
3. **Trailing `&`** — produced a spurious empty key in the params array

### Related Pull Requests

None.

### Fixed Issues

1. Fixes mage-os/mageos-magento2#262

### Manual testing scenarios

```php
$resolver = new QueryParamsResolver();

// Valueless param — no longer warns, returns empty string
$resolver->setQuery('foo&bar=1');
assert($resolver->getQueryParams() === ['foo' => '', 'bar' => '1']);

// Base64 value — no longer truncated
$resolver->setQuery('token=abc==');
assert($resolver->getQueryParams()['token'] === 'abc==');

// Trailing ampersand — no longer produces empty key
$resolver->setQuery('foo=bar&');
assert(!array_key_exists('', $resolver->getQueryParams()));
```

### Compatibility note

The `explode('=', $param, 2)` change causes values that were previously silently truncated (any param value containing `=`) to now return their full, correct value. Code that was compensating for the truncation would see different output. This is intentional — the previous behaviour was a data corruption bug.

### Test results

Three new test cases added to the existing `QueryParamsResolverTest`:

```
Query Params Resolver (Magento\Framework\Url\Test\Unit\QueryParamsResolver)
 ✔ Get query
 ✔ Get query escaped
 ✔ Set query
 ✔ Set query idempotent
 ✔ Set query param
 ✔ Set query params
 ✔ Add query params idempotent
 ✔ Get query params with valueless param
 ✔ Get query params preserves equals in value
 ✔ Get query params ignores trailing ampersand

OK (10 tests, 14 assertions)
```

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (all builds are green)