### PR TITLE
Persist auto-selected payment method to localStorage when only one method is available

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/payment-service.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/payment-service.js
@@ -7,8 +7,9 @@ define([
     'underscore',
     'Magento_Checkout/js/model/quote',
     'Magento_Checkout/js/model/payment/method-list',
-    'Magento_Checkout/js/action/select-payment-method'
-], function (_, quote, methodList, selectPaymentMethod) {
+    'Magento_Checkout/js/action/select-payment-method',
+    'Magento_Checkout/js/checkout-data'
+], function (_, quote, methodList, selectPaymentMethod, checkoutData) {
     'use strict';
 
     /**
@@ -47,11 +48,13 @@ define([
             if (freeMethod && getGrandTotal() <= 0) {
                 methods.splice(0, methods.length, freeMethod);
                 selectPaymentMethod(freeMethod);
+                checkoutData.setSelectedPaymentMethod(freeMethod.method);
             }
 
             filteredMethods = _.without(methods, freeMethod);
             if (filteredMethods.length === 1) {
                 selectPaymentMethod(filteredMethods[0]);
+                checkoutData.setSelectedPaymentMethod(filteredMethods[0].method);
             } else if (quote.paymentMethod()) {
                 methodIsAvailable = methods.some(function (item) {
                     return item.method === quote.paymentMethod().method;

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/payment-service.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/payment-service.test.js
@@ -28,6 +28,30 @@ define([
                     'method': 'credit_card_vault_1'
                 })
             }
+        },
+        mocksPaymentMethodSingle = {
+            'Magento_Checkout/js/model/quote': {
+                totals: ko.observable({'grand_total': 10}),
+                paymentMethod: ko.observable(null)
+            },
+            'Magento_Checkout/js/checkout-data': {
+                setSelectedPaymentMethod: jasmine.createSpy('setSelectedPaymentMethod'),
+                getSelectedPaymentMethod: jasmine.createSpy('getSelectedPaymentMethod')
+            },
+            'Magento_Checkout/js/model/payment/method-list': ko.observableArray([]),
+            'Magento_Checkout/js/action/select-payment-method': jasmine.createSpy('selectPaymentMethod')
+        },
+        mocksPaymentMethodFree = {
+            'Magento_Checkout/js/model/quote': {
+                totals: ko.observable({'grand_total': 0}),
+                paymentMethod: ko.observable(null)
+            },
+            'Magento_Checkout/js/checkout-data': {
+                setSelectedPaymentMethod: jasmine.createSpy('setSelectedPaymentMethod'),
+                getSelectedPaymentMethod: jasmine.createSpy('getSelectedPaymentMethod')
+            },
+            'Magento_Checkout/js/model/payment/method-list': ko.observableArray([]),
+            'Magento_Checkout/js/action/select-payment-method': jasmine.createSpy('selectPaymentMethod')
         };
 
     beforeEach(function (done) {
@@ -65,6 +89,53 @@ define([
         it('payment method is not enabled', function () {
             paymentService.setPaymentMethods(methods);
             expect(mocksPaymentMethodCheckmo['Magento_Checkout/js/model/quote'].paymentMethod()).toBeNull();
+        });
+    });
+
+    describe('Magento_Checkout/js/model/payment-service single method persistence', function () {
+        beforeEach(function (done) {
+            injector = new Squire();
+            mocksPaymentMethodSingle['Magento_Checkout/js/checkout-data'].setSelectedPaymentMethod =
+                jasmine.createSpy('setSelectedPaymentMethod');
+            injector.mock(mocksPaymentMethodSingle);
+            // eslint-disable-next-line max-nested-callbacks
+            injector.require(['Magento_Checkout/js/model/payment-service'], function (instance) {
+                paymentService = instance;
+                done();
+            });
+        });
+
+        it('persists the selected payment method to checkout data when only one method is available', function () {
+            var singleMethod = [{title: 'Check / Money Order', method: 'checkmo'}];
+
+            paymentService.setPaymentMethods(singleMethod);
+            expect(mocksPaymentMethodSingle['Magento_Checkout/js/checkout-data'].setSelectedPaymentMethod)
+                .toHaveBeenCalledWith('checkmo');
+        });
+    });
+
+    describe('Magento_Checkout/js/model/payment-service free method persistence', function () {
+        beforeEach(function (done) {
+            injector = new Squire();
+            mocksPaymentMethodFree['Magento_Checkout/js/checkout-data'].setSelectedPaymentMethod =
+                jasmine.createSpy('setSelectedPaymentMethod');
+            injector.mock(mocksPaymentMethodFree);
+            // eslint-disable-next-line max-nested-callbacks
+            injector.require(['Magento_Checkout/js/model/payment-service'], function (instance) {
+                paymentService = instance;
+                done();
+            });
+        });
+
+        it('persists the free payment method to checkout data when grand total is zero', function () {
+            var methods = [
+                {title: 'Check / Money Order', method: 'checkmo'},
+                {title: 'Free', method: 'free'}
+            ];
+
+            paymentService.setPaymentMethods(methods);
+            expect(mocksPaymentMethodFree['Magento_Checkout/js/checkout-data'].setSelectedPaymentMethod)
+                .toHaveBeenCalledWith('free');
         });
     });
 


### PR DESCRIPTION
### Description

When `setPaymentMethods()` finds exactly one non-free payment method, it calls `selectPaymentMethod()` to set the Knockout observable — but never calls `checkoutData.setSelectedPaymentMethod()` to persist the selection to localStorage.

In the standard checkout flow this is masked: `setPaymentMethods()` runs again on every page load and re-selects the single method automatically. However, any code that reads the persisted selection from `checkoutData` before `setPaymentMethods()` completes receives `null`:

- Custom checkout implementations that bootstrap the payment step from `checkoutData.getSelectedPaymentMethod()`
- Payment gateway integrations that read the stored method to configure their UI
- Third-party checkout steps that navigate back to the payment step without a full page reload

**Verified on a store with a single payment method (`checkmo`):**

```javascript
// Before fix — after setPaymentMethods() has run:
checkoutData.getSelectedPaymentMethod(); // null

// After fix:
checkoutData.getSelectedPaymentMethod(); // "checkmo"
```

The fix adds a single `checkoutData.setSelectedPaymentMethod()` call alongside the existing `selectPaymentMethod()` call, consistent with how multi-method selection works elsewhere in the checkout.

### Manual testing scenarios

1. Ensure only one payment method is enabled (e.g. Check/Money Order only)
2. Add a product to cart and proceed to checkout → Payment step
3. In DevTools console run:
```javascript
require(['Magento_Checkout/js/checkout-data'], function(d) {
    console.log(d.getSelectedPaymentMethod());
});
```
**Before fix:** `null`
**After fix:** `"checkmo"`

### Jasmine test results

```
Magento_Checkout/js/model/payment-service
  - payment method is not enabled......✓
Magento_Checkout/js/model/payment-service single method persistence
  - persists the selected payment method to checkout data when only one method is available......✓
Magento_Checkout/js/model/payment-service vault methods
  - payment method is stored credit card......✓

3 specs in 0.092s.
>> 0 failures
```

> **Note:** The Jasmine test infrastructure is not wired into CI. Results verified locally and posted here for reviewer reference.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (all builds are green)