### PR TITLE
Let PaymentException propagate from savePaymentInformationAndPlaceOrder

### DIFF
--- a/app/code/Magento/Checkout/Model/PaymentInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/PaymentInformationManagement.php
@@ -14,6 +14,7 @@ use Magento\Customer\Api\Data\AddressInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\PaymentException;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\Data\AddressInterface as QuoteAddressInterface;
 use Magento\Quote\Api\Data\PaymentInterface;
@@ -173,6 +174,9 @@ class PaymentInformationManagement implements \Magento\Checkout\Api\PaymentInfor
                     'is_guest_checkout' => false
                 ]
             );
+            if ($e instanceof PaymentException) {
+                throw $e;
+            }
             throw new CouldNotSaveException(
                 __($e->getMessage()),
                 $e

--- a/app/code/Magento/Checkout/Test/Unit/Model/PaymentInformationManagementTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/PaymentInformationManagementTest.php
@@ -17,6 +17,7 @@ use Magento\Customer\Api\Data\AddressInterface as CustomerAddressInterface;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Api\AddressRepositoryInterface;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\PaymentException;
 use Magento\Framework\Phrase;
 use Magento\Quote\Api\BillingAddressManagementInterface;
 use Magento\Quote\Api\CartManagementInterface;
@@ -236,6 +237,25 @@ class PaymentInformationManagementTest extends TestCase
         $this->paymentMethodManagementMock->expects($this->any())->method('set')->with($cartId, $paymentMock);
         $phrase = new Phrase(__('DB exception'));
         $exception = new LocalizedException($phrase);
+        $this->cartManagementMock->expects($this->any())->method('placeOrder')->willThrowException($exception);
+
+        $this->model->savePaymentInformationAndPlaceOrder($cartId, $paymentMock, $billingAddressMock);
+    }
+
+    public function testSavePaymentInformationAndPlaceOrderWithPaymentException()
+    {
+        $this->expectException(PaymentException::class);
+        $this->expectExceptionMessage('Payment declined');
+        $cartId = 100;
+        $paymentMock = $this->createMock(PaymentInterface::class);
+        $billingAddressMock = $this->createMock(AddressInterface::class);
+
+        $this->getMockForAssignBillingAddress($cartId, $billingAddressMock);
+
+        $this->paymentMethodManagementMock->expects($this->any())->method('set')->with($cartId, $paymentMock);
+        $phrase = new Phrase(__('Payment declined'));
+        $exception = new PaymentException($phrase);
+        $this->loggerMock->expects($this->any())->method('critical');
         $this->cartManagementMock->expects($this->any())->method('placeOrder')->willThrowException($exception);
 
         $this->model->savePaymentInformationAndPlaceOrder($cartId, $paymentMock, $billingAddressMock);


### PR DESCRIPTION
### Description

`PaymentInformationManagement::savePaymentInformationAndPlaceOrder()` catches all exceptions from `placeOrder()` and rethrows them as `CouldNotSaveException`. This swallows `PaymentException`, which payment gateways (Mollie, Braintree, Adyen, and others) throw specifically to trigger redirect-after-failure flows.

**Current behaviour:** Payment gateway throws `PaymentException` → caught → rethrown as `CouldNotSaveException` → gateway's handler never sees it → customer gets a generic "An error occurred" message with no way to retry.

**Expected behaviour:** `PaymentException` propagates → gateway's error handler catches it → customer is redirected back to the payment form to retry or choose a different card.

### Fix approach

Rather than changing all exceptions to `PaymentException` (which would be a larger BC break and semantically wrong for DB errors), only `PaymentException` is re-thrown as-is. All other `LocalizedException` subclasses and generic exceptions continue to become `CouldNotSaveException`:

```php
} catch (LocalizedException $e) {
    $this->logger->critical(...);
    if ($e instanceof PaymentException) {
        throw $e;  // propagate as-is so gateway handlers can catch it
    }
    throw new CouldNotSaveException(__($e->getMessage()), $e);
} catch (\Exception $e) {
    // non-payment errors remain CouldNotSaveException — unchanged
    throw new CouldNotSaveException('A server error...', $e);
}
```

### ⚠️ Potential BC break

Any code that `catch (CouldNotSaveException $e)` on this call path and specifically handles payment failures will no longer catch `PaymentException`. This is intentional — such code should be catching `PaymentException` in the first place. However, third-party modules relying on the current (incorrect) wrapping behaviour may need to update their catch blocks.

### Manual testing scenarios

1. Install a payment gateway that throws `PaymentException` on failure (Mollie, Braintree)
2. Attempt checkout with a card that will be declined
3. **Before fix:** Generic "An error occurred on the server" message, no redirect
4. **After fix:** Gateway redirect-after-failure flow triggers correctly

### Test results

```
Payment Information Management
 ✔ Save payment information and place order
 ✔ Save payment information and place order limited
 ✔ Save payment information and place order exception
 ✔ Save payment information and place order if billing address not exist
 ✔ Save payment information
 ✔ Save payment information limited
 ✔ Save payment information without billing address
 ✔ Save payment information and place order with locolized exception
 ✔ Save payment information and place order with payment exception
 ✔ Save payment information and place order with new billing address

OK (10 tests, 48 assertions)
```

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (all builds are green)