### PR TITLE
Map HTTP 429 Too Many Requests in WebAPI ErrorProcessor

### DIFF
--- a/app/code/Magento/Checkout/Api/Exception/PaymentProcessingRateLimitExceededException.php
+++ b/app/code/Magento/Checkout/Api/Exception/PaymentProcessingRateLimitExceededException.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Magento\Checkout\Api\Exception;
 
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
 
 /**
  * Thrown when too many payment processing/saving requests have been initiated by a user.
@@ -17,5 +18,12 @@ use Magento\Framework\Exception\LocalizedException;
  */
 class PaymentProcessingRateLimitExceededException extends LocalizedException
 {
-
+    /**
+     * @param Phrase $phrase
+     * @param \Exception|null $cause
+     */
+    public function __construct(Phrase $phrase, ?\Exception $cause = null)
+    {
+        parent::__construct($phrase, $cause, 429);
+    }
 }

--- a/app/code/Magento/Checkout/Api/Exception/PaymentProcessingRateLimitExceededException.php
+++ b/app/code/Magento/Checkout/Api/Exception/PaymentProcessingRateLimitExceededException.php
@@ -21,9 +21,10 @@ class PaymentProcessingRateLimitExceededException extends LocalizedException
     /**
      * @param Phrase $phrase
      * @param \Exception|null $cause
+     * @param int $code
      */
-    public function __construct(Phrase $phrase, ?\Exception $cause = null)
+    public function __construct(Phrase $phrase, ?\Exception $cause = null, int $code = 429)
     {
-        parent::__construct($phrase, $cause, 429);
+        parent::__construct($phrase, $cause, $code);
     }
 }

--- a/app/code/Magento/Checkout/Test/Unit/Api/Exception/PaymentProcessingRateLimitExceededExceptionTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Api/Exception/PaymentProcessingRateLimitExceededExceptionTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright 2020 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Checkout\Test\Unit\Api\Exception;
+
+use Magento\Checkout\Api\Exception\PaymentProcessingRateLimitExceededException;
+use Magento\Framework\Phrase;
+use PHPUnit\Framework\TestCase;
+
+class PaymentProcessingRateLimitExceededExceptionTest extends TestCase
+{
+    public function testExceptionHas429Code(): void
+    {
+        $exception = new PaymentProcessingRateLimitExceededException(new Phrase('Too many requests'));
+
+        $this->assertSame(429, $exception->getCode());
+    }
+
+    public function testExceptionPreservesCause(): void
+    {
+        $cause = new \Exception('Original cause');
+        $exception = new PaymentProcessingRateLimitExceededException(new Phrase('Too many requests'), $cause);
+
+        $this->assertSame($cause, $exception->getPrevious());
+        $this->assertSame(429, $exception->getCode());
+    }
+}

--- a/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
@@ -206,6 +206,10 @@ class ErrorProcessor
             || ($exception instanceof AuthenticationException)
         ) {
             return WebapiException::HTTP_UNAUTHORIZED;
+        } elseif (((int)$exception->getPrevious()?->getCode() === WebapiException::HTTP_TOO_MANY_REQUESTS)
+            || ((int)$exception->getCode() === WebapiException::HTTP_TOO_MANY_REQUESTS)
+        ) {
+            return WebapiException::HTTP_TOO_MANY_REQUESTS;
         } else {
             return WebapiException::HTTP_BAD_REQUEST;
         }

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/ErrorProcessorTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/ErrorProcessorTest.php
@@ -11,6 +11,7 @@ namespace Magento\Framework\Webapi\Test\Unit;
 
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\AuthorizationException;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Json\Encoder;
@@ -313,7 +314,22 @@ class ErrorProcessorTest extends TestCase
                 WebapiException::HTTP_INTERNAL_ERROR,
                 'Internal Error. Details are available in Magento log file. Report ID:',
                 [],
-            ]
+            ],
+            'LocalizedException with HTTP 429 code' => [
+                new LocalizedException(new Phrase('Too many requests'), null, 429),
+                WebapiException::HTTP_TOO_MANY_REQUESTS,
+                'Too many requests',
+                [],
+            ],
+            'LocalizedException wrapping exception with HTTP 429 code' => [
+                new LocalizedException(
+                    new Phrase('Too many requests'),
+                    new \Exception('Rate limit exceeded', 429)
+                ),
+                WebapiException::HTTP_TOO_MANY_REQUESTS,
+                'Too many requests',
+                [],
+            ],
         ];
     }
 


### PR DESCRIPTION
### Description

Two related gaps prevented HTTP 429 Too Many Requests from reaching API clients correctly.

---

#### Part 1 — `ErrorProcessor::getHttpCodeForLocalizedException()`

The method mapped exception types to HTTP codes but had no case for 429. Any `LocalizedException` with code 429 fell through to `400 Bad Request`, making it impossible for API clients to distinguish rate limiting from a bad request and implement correct retry-after behaviour.

**Fix:** Added a 429 branch that checks both `$exception->getCode()` and `$exception->getPrevious()?->getCode()`.

---

#### Part 2 — `PaymentProcessingRateLimitExceededException`

The built-in rate limit exception extended `LocalizedException` with **no code set** (defaulted to 0), so it never triggered the 429 branch above. When `savePaymentInformationAndPlaceOrder()` called `$this->paymentRateLimiter->limit()` without a try/catch, the exception propagated to the WebAPI layer and produced `400` instead of `429`.

**Fix:** Added a constructor that sets code 429, closing the full chain:

```
paymentRateLimiter->limit()
  → throws PaymentProcessingRateLimitExceededException (code 429)
  → caught by ErrorProcessor as LocalizedException
  → getHttpCodeForLocalizedException() matches code 429
  → HTTP 429 Too Many Requests returned to API client
```

---

### Manual testing scenarios

1. Trigger the payment rate limiter via `POST /V1/carts/{cartId}/payment-information` repeatedly
2. Inspect the HTTP response code — should now be `429` instead of `400`

### Test results

```
Error Processor (Magento\Framework\Webapi\Test\Unit\ErrorProcessor)
 ✔ Mask exception with data set "LocalizedException with HTTP 429 code"
 ✔ Mask exception with data set "LocalizedException wrapping exception with HTTP 429 code"
 ... (16 total)

Payment Processing Rate Limit Exceeded Exception
 ✔ Exception has 429 code
 ✔ Exception preserves cause

OK (18 tests, 58 assertions)
```

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (all builds are green)