### PR TITLE
Call backend model afterLoad() even when config value is locked in deployment config

### DIFF
--- a/app/code/Magento/Config/Block/System/Config/Form.php
+++ b/app/code/Magento/Config/Block/System/Config/Form.php
@@ -415,27 +415,27 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         );
 
         if ($placeholderValue) {
-            $data = $placeholderValue;
+            return $placeholderValue;
         }
 
         if ($data === null) {
-            $path = $field->getConfigPath() !== null ? $field->getConfigPath() : $path;
             $data = $this->getConfigValue($path);
-            if ($field->hasBackendModel()) {
-                $backendModel = $field->getBackendModel();
-                // Backend models which implement ProcessorInterface are processed by ScopeConfigInterface
-                if (!$backendModel instanceof ProcessorInterface) {
-                    if (array_key_exists($path, $this->_configData)) {
-                        $data = $this->_configData[$path];
-                    }
+        }
 
-                    $backendModel->setPath($path)
-                        ->setValue($data)
-                        ->setWebsite($this->getWebsiteCode())
-                        ->setStore($this->getStoreCode())
-                        ->afterLoad();
-                    $data = $backendModel->getValue();
+        if ($field->hasBackendModel()) {
+            $backendModel = $field->getBackendModel();
+            // Backend models which implement ProcessorInterface are processed by ScopeConfigInterface
+            if (!$backendModel instanceof ProcessorInterface) {
+                if (array_key_exists($path, $this->_configData)) {
+                    $data = $this->_configData[$path];
                 }
+
+                $backendModel->setPath($path)
+                    ->setValue($data)
+                    ->setWebsite($this->getWebsiteCode())
+                    ->setStore($this->getStoreCode())
+                    ->afterLoad();
+                $data = $backendModel->getValue();
             }
         }
 

--- a/app/code/Magento/Config/Test/Unit/Block/System/Config/FormTest.php
+++ b/app/code/Magento/Config/Test/Unit/Block/System/Config/FormTest.php
@@ -23,6 +23,7 @@ use Magento\Config\Model\Config\Structure\Element\Group;
 use Magento\Config\Model\Config\Structure\Element\Section;
 use Magento\Config\Model\Config\Structure\ElementVisibilityInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Value as ConfigValue;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\ObjectManager as AppObjectManager;
@@ -553,6 +554,102 @@ class FormTest extends TestCase
         $helper->setBackwardCompatibleProperty($this->object, 'elementVisibility', $elementVisibilityMock);
 
         $this->object->initFields($fieldsetMock, $groupMock, $sectionMock, $fieldPrefix, $labelPrefix);
+    }
+
+    /**
+     * Regression test: afterLoad() must be called on backend models even when the value
+     * is already present in the deployment config (app/etc/config.php via --lock-config).
+     *
+     * Before the fix, getFieldData() only called afterLoad() inside the `if ($data === null)`
+     * block. When a configPath value was locked, getAppConfigDataValue() returned non-null,
+     * skipping the entire block — including afterLoad() — so backend model processing was lost.
+     */
+    public function testAfterLoadIsCalledWhenValueComesFromDeploymentConfig(): void
+    {
+        $fieldPath   = 'section1/group1/field1';
+        $lockedValue = 'locked_raw_value';
+
+        // Deployment config returns a non-null value for the field path (simulates --lock-config)
+        $deploymentConfigMock = $this->createMock(DeploymentConfig::class);
+        $deploymentConfigMock->method('get')
+            ->with('system')
+            ->willReturn([
+                'stores' => [
+                    'store_code' => [
+                        'section1' => [
+                            'group1' => [
+                                'field1' => $lockedValue
+                            ]
+                        ]
+                    ]
+                ]
+            ]);
+
+        $objectManagerMock = $this->createMock(ObjectManagerInterface::class);
+        $objectManagerMock->method('get')
+            ->willReturnMap([[DeploymentConfig::class, $deploymentConfigMock]]);
+        AppObjectManager::setInstance($objectManagerMock);
+
+        // Backend model that transforms the value in afterLoad()
+        // setPath/setValue/setWebsite/setStore are DataObject magic methods handled by __call;
+        // only mock afterLoad() and getValue() which are explicitly defined on the class.
+        $backendModelMock = $this->getMockBuilder(ConfigValue::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['afterLoad'])
+            ->getMock();
+        $backendModelMock->expects($this->once())->method('afterLoad')->willReturnSelf();
+
+        $fieldMock = $this->createMock(StructureField::class);
+        $fieldMock->method('getPath')->willReturn($fieldPath);
+        $fieldMock->method('getConfigPath')->willReturn($fieldPath);
+        $fieldMock->method('getGroupPath')->willReturn('section1/group1');
+        $fieldMock->method('getSectionId')->willReturn('section1');
+        $fieldMock->method('hasBackendModel')->willReturn(true);
+        $fieldMock->method('getBackendModel')->willReturn($backendModelMock);
+        $fieldMock->method('getDependencies')->willReturn([]);
+        $fieldMock->method('getType')->willReturn('text');
+        $fieldMock->method('getLabel')->willReturn('label');
+        $fieldMock->method('getComment')->willReturn('comment');
+        $fieldMock->method('getTooltip')->willReturn('tooltip');
+        $fieldMock->method('getHint')->willReturn('hint');
+        $fieldMock->method('getFrontendClass')->willReturn('');
+        $fieldMock->method('showInDefault')->willReturn(false);
+        $fieldMock->method('showInWebsite')->willReturn(false);
+        $fieldMock->method('getData')->willReturn([]);
+        $fieldMock->method('getRequiredFields')->willReturn([]);
+        $fieldMock->method('getRequiredGroups')->willReturn([]);
+
+        $fieldRendererMock = $this->createMock(Field::class);
+        $this->_fieldFactoryMock->method('create')->willReturn($fieldRendererMock);
+
+        $this->_backendConfigMock->method('extendConfig')->willReturn([]);
+
+        $storeMock = $this->createMock(StoreInterface::class);
+        $storeMock->method('getCode')->willReturn('store_code');
+        $this->storeManagerMock->method('getStore')->willReturn($storeMock);
+
+        $fieldsetMock  = $this->createMock(FieldsetElement::class);
+        $groupMock     = $this->createMock(Group::class);
+        $sectionMock   = $this->createMock(Section::class);
+
+        $groupMock->method('getChildren')->willReturn([$fieldMock]);
+        $sectionMock->method('getId')->willReturn('section1');
+
+        $formFieldMock = $this->createPartialMock(AbstractElement::class, ['setRenderer']);
+        $fieldsetMock->method('addField')->willReturn($formFieldMock);
+
+        $settingCheckerMock = $this->createMock(SettingChecker::class);
+        $settingCheckerMock->method('getPlaceholderValue')->willReturn(null);
+        $settingCheckerMock->method('isReadOnly')->willReturn(false);
+
+        $elementVisibilityMock = $this->createMock(ElementVisibilityInterface::class);
+        $elementVisibilityMock->method('isDisabled')->willReturn(false);
+
+        $helper = new ObjectManager($this);
+        $helper->setBackwardCompatibleProperty($this->object, 'settingChecker', $settingCheckerMock);
+        $helper->setBackwardCompatibleProperty($this->object, 'elementVisibility', $elementVisibilityMock);
+
+        $this->object->initFields($fieldsetMock, $groupMock, $sectionMock, '', '');
     }
 
     /**


### PR DESCRIPTION
### Description

#### The bug

`Config\Block\System\Config\Form::getFieldData()` processes config field values before rendering them in the admin form. When a field uses `<config_path>` to point to a value stored at a different config path, the rendering flow is:

1. Line 305 resolves `$path` to the `<config_path>` value **before** `getFieldData()` is called
2. `getAppConfigDataValue($path)` reads `app/etc/config.php` (the deployment config) for that path
3. If the value is present in `app/etc/config.php` (locked via `bin/magento config:set --lock-config`), the method returns it as non-null
4. The `if ($data === null)` block — which contains the `afterLoad()` call — is **skipped entirely**
5. The raw, unprocessed value from the deployment config is returned and displayed

**Consequence:** Any admin config field that uses `<config_path>` with a backend model (`Encrypted`, `Serialized`, or custom) will display the raw stored value when that path is locked:

- `Encrypted` backend: admin sees the raw ciphertext `0:3:GN7gCXocVP8yO...` instead of the decrypted value
- `Serialized` backend: admin sees the raw serialised string instead of the decoded structure
- Custom backend: `afterLoad()` transformation is silently skipped

This is particularly damaging for payment gateway configuration, where API keys are stored encrypted and displayed with `<config_path>`. Any deployment using `--lock-config` for these fields (common in CI/CD pipelines) would expose the raw encrypted strings in the admin form.

#### Root cause

```php
// Before fix — afterLoad() only reachable when $data is null
if ($data === null) {
    $path = $field->getConfigPath() !== null ? $field->getConfigPath() : $path;
    $data = $this->getConfigValue($path);
    if ($field->hasBackendModel()) {
        $backendModel = $field->getBackendModel();
        if (!$backendModel instanceof ProcessorInterface) {
            // ...
            $backendModel->afterLoad();   // ← NEVER REACHED when locked in config.php
            $data = $backendModel->getValue();
        }
    }
}
```

Note also that line 305 already resolves `<config_path>` before calling `getFieldData()`, making the `$path = $field->getConfigPath() ?: $path` line inside the `if` block redundant — it was setting `$path` to the same value it already had.

#### Fix

Move the backend model processing outside the null guard. Also change the placeholder value (`--lock-env` / ENV variables) path to an early return, since ENV placeholders bypass the config layer entirely and should not be processed by backend models:

```php
// After fix
if ($placeholderValue) {
    return $placeholderValue;      // ENV override: skip backend model entirely
}

if ($data === null) {
    $data = $this->getConfigValue($path);
}

// Always call afterLoad() — regardless of whether value came from
// deployment config or core_config_data
if ($field->hasBackendModel()) {
    $backendModel = $field->getBackendModel();
    if (!$backendModel instanceof ProcessorInterface) {
        if (array_key_exists($path, $this->_configData)) {
            $data = $this->_configData[$path];
        }
        $backendModel->setPath($path)->setValue($data)->...->afterLoad();
        $data = $backendModel->getValue();
    }
}
```

#### Reproduction

```bash
# Set a value at path A (the configPath target)
bin/magento config:set some/section/field_a 'mysecretvalue'

# Lock it in deployment config
bin/magento config:set --lock-config some/section/field_a 'mysecretvalue'
bin/magento cache:flush
```

A field at any path with `<config_path>some/section/field_a` and a backend model will now skip `afterLoad()`. Before this fix, the field displays the raw value from config.php without backend model processing.

### ⚠️ Potential BC impact

**Standard backend models — no impact:**
- Backend models implementing `ProcessorInterface` (e.g. `Encrypted`) are excluded from manual `afterLoad()` calls by the existing `if (!$backendModel instanceof ProcessorInterface)` guard — unchanged by this fix
- Fields without `<config_path>` — code path unchanged
- Fields whose configPath is **not** locked in `app/etc/config.php` — `getAppConfigDataValue()` returns null; same path as before

**Theoretical risk:**
- A custom backend model that (1) does not implement `ProcessorInterface`, (2) is on a field with `<config_path>`, and (3) has a non-idempotent `afterLoad()` that produces incorrect output when called on an already-processed value. Such a backend model would have been relying on the buggy behaviour (afterLoad not being called on locked values). This is an extremely narrow edge case.

**ENV placeholder values (`--lock-env`) — unchanged:**
`getPlaceholderValue()` now triggers an early return before backend model processing, preserving the existing behaviour (ENV overrides bypass backend models entirely).

### Manual testing scenarios

1. Create a system config field with `<config_path>` and a backend model that transforms `afterLoad()` output
2. Set and lock the configPath value: `bin/magento config:set --lock-config <configPath> 'value'`
3. Flush cache: `bin/magento cache:flush`
4. Navigate to the admin config section

**Before fix:** Field displays raw value from config.php — `afterLoad()` not called
**After fix:** Field displays backend model-processed value — `afterLoad()` called correctly

### Test results

```
Form (Magento\Config\Test\Unit\Block\System\Config\Form)
 ✔ Init form with data set #0
 ✔ Init form with data set #1
 ✔ Init group with data set #0
 ✔ Init group with data set #1
 ✔ Init group with data set #2
 ✔ Init fields with data set #0
 ✔ Init fields with data set #1
 ✔ Init fields with data set #2
 ✔ Init fields with data set #3
 ✔ After load is called when value comes from deployment config

OK (10 tests, 167 assertions)
```

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (all builds are green)