### PR TITLE
Include scope ID in Url cache key to prevent multi-store URL collision

### DIFF
--- a/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
@@ -286,6 +286,51 @@ class UrlTest extends TestCase
         $this->assertEquals($returnUri, $url);
     }
 
+    public function testGetUrlCacheIsIsolatedByScope(): void
+    {
+        $routeConfigMock = $this->createMock(ConfigInterface::class);
+        $model = $this->getUrlModel(
+            [
+                'scopeResolver' => $this->scopeResolverMock,
+                'routeParamsResolverFactory' => $this->getRouteParamsResolverFactory(),
+                'queryParamsResolver' => $this->queryParamsResolverMock,
+                'request' => $this->getRequestMock(),
+                'routeConfig' => $routeConfigMock,
+                'routeParamsPreprocessor' => $this->routeParamsPreprocessorMock,
+            ]
+        );
+
+        $urlType = UrlInterface::URL_TYPE_LINK;
+
+        $scope1 = $this->createMock(ScopeInterface::class);
+        $scope1->method('getId')->willReturn(1);
+        $scope1->method('getBaseUrl')->willReturn('http://store1.example.com/');
+
+        $scope2 = $this->createMock(ScopeInterface::class);
+        $scope2->method('getId')->willReturn(2);
+        $scope2->method('getBaseUrl')->willReturn('http://store2.example.com/');
+
+        $this->routeParamsResolverMock->method('getType')->willReturn($urlType);
+        $this->routeParamsResolverMock->method('getRouteParams')->willReturn([]);
+        $this->routeParamsPreprocessorMock->method('execute')->willReturnArgument(2);
+        $routeConfigMock->method('getRouteFrontName')->willReturn('catalog');
+        $this->queryParamsResolverMock->method('getQuery')->willReturn('');
+
+        $this->scopeResolverMock->method('getScope')->willReturn($scope1);
+
+        // Set scope1 directly, bypassing the resolver
+        $model->setData('scope', $scope1);
+        $url1 = $model->getUrl('catalog/product/view', ['_nosid' => 1]);
+
+        // Switch to scope2 directly — this is what happens in multi-store requests
+        $model->setData('scope', $scope2);
+        $url2 = $model->getUrl('catalog/product/view', ['_nosid' => 1]);
+
+        $this->assertNotEquals($url1, $url2, 'URLs for different stores must not share a cache entry');
+        $this->assertStringContainsString('store1.example.com', $url1);
+        $this->assertStringContainsString('store2.example.com', $url2);
+    }
+
     /**
      * @return void
      */

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -873,7 +873,8 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             ksort($cachedParams);
         }
 
-        $cacheKey = sha1($routePath . $this->serializer->serialize($cachedParams) . ($this->_getScope() ? $this->_getScope()->getId() : 0));
+        $scopeId = $this->_getScope() ? $this->_getScope()->getId() : 0;
+        $cacheKey = sha1($routePath . $this->serializer->serialize($cachedParams) . $scopeId);
         if (!isset($this->cacheUrl[$cacheKey])) {
             $this->cacheUrl[$cacheKey] = $this->getUrlModifier()->execute(
                 $this->createUrl($routePath, $routeParams)

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -873,7 +873,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             ksort($cachedParams);
         }
 
-        $cacheKey = sha1($routePath . $this->serializer->serialize($cachedParams));
+        $cacheKey = sha1($routePath . $this->serializer->serialize($cachedParams) . ($this->_getScope() ? $this->_getScope()->getId() : 0));
         if (!isset($this->cacheUrl[$cacheKey])) {
             $this->cacheUrl[$cacheKey] = $this->getUrlModifier()->execute(
                 $this->createUrl($routePath, $routeParams)


### PR DESCRIPTION
### Description

`Url::_getUrl()` caches generated URLs in `$this->cacheUrl` keyed by:

```php
$cacheKey = sha1($routePath . $this->serializer->serialize($cachedParams));
```

No store scope identifier is included. When the same `Url` instance is reused across different store scopes — which occurs in multi-store requests and long-lived CLI processes — the cached URL for store A is returned when store B is requested.

#### Reproduction

Setup: two stores with different base URLs (`app.mageos.test` and `store.mageos.test`).

```php
$urlModel = $objectManager->get(UrlInterface::class);

$storeManager->setCurrentStore('default');
$urlModel->setScope('default');
$url1 = $urlModel->getUrl('catalog/product/view', ['id' => 42]);
// → https://app.mageos.test/catalog/product/view/id/42/  ✓

$storeManager->setCurrentStore('store2_view');
$urlModel->setScope('store2_view');
$url2 = $urlModel->getUrl('catalog/product/view', ['id' => 42]);
// → https://app.mageos.test/catalog/product/view/id/42/  ✗ (wrong — cache collision)
```

Both URLs are identical despite different base URLs because the cache key is the same.

#### Fix

Append the current scope ID to the cache key:

```diff
- $cacheKey = sha1($routePath . $this->serializer->serialize($cachedParams));
+ $cacheKey = sha1($routePath . $this->serializer->serialize($cachedParams) . ($this->_getScope() ? $this->_getScope()->getId() : 0));
```

After fix:
```
Store 1: https://app.mageos.test/catalog/product/view/id/42/   ✓
Store 2: https://store.mageos.test/catalog/product/view/id/42/ ✓
```

### Test results

```
Url (Magento\Framework\Test\Unit\Url)
 ✔ Get url with data set "string query"
 ✔ Get url with data set "array query"
 ✔ Get url with data set "without query"
 ✔ Get url cache is isolated by scope
 ✔ Get url idempotent set route path
 ... (32 total)

OK (32 tests, 104 assertions)
```

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (all builds are green)