### PR TITLE
Add ORDER BY to compare list collection in Block and Helper

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/Compare/ListCompare.php
+++ b/app/code/Magento/Catalog/Block/Product/Compare/ListCompare.php
@@ -155,7 +155,7 @@ class ListCompare extends \Magento\Catalog\Block\Product\AbstractProduct
                 $this->_catalogConfig->getProductAttributes()
             )->loadComparableAttributes()->addMinimalPrice()->addTaxPercents()->setVisibility(
                 $this->_catalogProductVisibility->getVisibleInSiteIds()
-            );
+            )->addOrder('catalog_compare_item_id', 'ASC');
         }
 
         return $this->_items;

--- a/app/code/Magento/Catalog/Helper/Product/Compare.php
+++ b/app/code/Magento/Catalog/Helper/Product/Compare.php
@@ -294,7 +294,9 @@ class Compare extends \Magento\Framework\Url\Helper\Data
             /* Price data is added to consider item stock status using price index */
             $this->_itemCollection->addPriceData();
 
-            $this->_itemCollection->addAttributeToSelect('name')->addUrlRewrite()->load();
+            $this->_itemCollection->addAttributeToSelect('name')->addUrlRewrite()
+                ->addOrder('catalog_compare_item_id', 'ASC')
+                ->load();
 
             /* update compare items count */
             $count = count($this->_itemCollection);

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/Compare/ListCompareTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/Compare/ListCompareTest.php
@@ -11,8 +11,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Catalog\Block\Product\Compare\ListCompare;
 use Magento\Catalog\Block\Product\Context;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Product\Compare\Item\Collection;
+use Magento\Catalog\Model\ResourceModel\Product\Compare\Item\CollectionFactory;
 use Magento\Eav\Model\Entity\Attribute\AttributeInterface;
 use Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend;
+use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\Pricing\Render;
 use Magento\Framework\TestFramework\Unit\Helper\MockCreationTrait;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
@@ -124,6 +127,71 @@ class ListCompareTest extends TestCase
             ->willReturn($blockMock);
 
         $this->assertEquals($expectedResult, $this->block->getProductPrice($product, '-compare-list-top'));
+    }
+
+    public function testGetItemsOrdersByCompareItemIdAscending(): void
+    {
+        $collectionMock = $this->getMockBuilder(Collection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['useProductItem', 'setStoreId', 'setCustomerId', 'setVisitorId',
+                'addAttributeToSelect', 'loadComparableAttributes', 'addMinimalPrice',
+                'addTaxPercents', 'setVisibility', 'addOrder'])
+            ->getMock();
+
+        $collectionMock->method('useProductItem')->willReturnSelf();
+        $collectionMock->method('setStoreId')->willReturnSelf();
+        $collectionMock->method('setVisitorId')->willReturnSelf();
+        $collectionMock->method('addAttributeToSelect')->willReturnSelf();
+        $collectionMock->method('loadComparableAttributes')->willReturnSelf();
+        $collectionMock->method('addMinimalPrice')->willReturnSelf();
+        $collectionMock->method('addTaxPercents')->willReturnSelf();
+        $collectionMock->method('setVisibility')->willReturnSelf();
+
+        $collectionMock->expects($this->once())
+            ->method('addOrder')
+            ->with('catalog_compare_item_id', 'ASC')
+            ->willReturnSelf();
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collectionMock);
+
+        $httpContext = $this->createMock(HttpContext::class);
+        $httpContext->method('getValue')->willReturn(false);
+
+        $objectManager = new ObjectManager($this);
+        $block = $objectManager->getObject(
+            ListCompare::class,
+            [
+                'context'               => $this->createPartialMock(Context::class, ['getLayout']),
+                'itemCollectionFactory' => $collectionFactory,
+                'httpContext'           => $httpContext,
+            ]
+        );
+
+        // Inject the required dependencies that come from Context
+        $compareProductMock = $this->getMockBuilder(\Magento\Catalog\Helper\Product\Compare::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setAllowUsedFlat'])
+            ->getMock();
+        $compareProductMock->method('setAllowUsedFlat')->willReturnSelf();
+
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->method('getId')->willReturn(1);
+        $storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
+        $storeManagerMock->method('getStore')->willReturn($storeMock);
+
+        $catalogVisibilityMock = $this->createMock(\Magento\Catalog\Model\Product\Visibility::class);
+        $catalogVisibilityMock->method('getVisibleInSiteIds')->willReturn([1, 2]);
+
+        $catalogConfigMock = $this->createMock(\Magento\Catalog\Model\Config::class);
+        $catalogConfigMock->method('getProductAttributes')->willReturn([]);
+
+        $objectManager->setBackwardCompatibleProperty($block, '_compareProduct', $compareProductMock);
+        $objectManager->setBackwardCompatibleProperty($block, '_storeManager', $storeManagerMock);
+        $objectManager->setBackwardCompatibleProperty($block, '_catalogProductVisibility', $catalogVisibilityMock);
+        $objectManager->setBackwardCompatibleProperty($block, '_catalogConfig', $catalogConfigMock);
+
+        $block->getItems();
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Helper/Product/CompareTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Helper/Product/CompareTest.php
@@ -9,7 +9,11 @@ namespace Magento\Catalog\Test\Unit\Helper\Product;
 
 use Magento\Catalog\Helper\Product\Compare;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Product\Compare\Item\Collection;
+use Magento\Catalog\Model\ResourceModel\Product\Compare\Item\CollectionFactory;
 use Magento\Catalog\Model\Session;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Customer\Model\Visitor;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\Request\Http;
@@ -208,5 +212,55 @@ class CompareTest extends TestCase
         $this->urlBuilder->expects($this->once())->method('getUrl')
             ->with('checkout/cart/add', $expectedResult);
         $this->compareHelper->getAddToCartUrl($productMock);
+    }
+
+    public function testGetItemCollectionOrdersByCompareItemIdAscending(): void
+    {
+        $collectionMock = $this->getMockBuilder(Collection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['useProductItem', 'setStoreId', 'setVisitorId', 'setVisibility',
+                'addPriceData', 'addAttributeToSelect', 'addUrlRewrite', 'addOrder', 'load'])
+            ->getMock();
+
+        $collectionMock->method('useProductItem')->willReturnSelf();
+        $collectionMock->method('setStoreId')->willReturnSelf();
+        $collectionMock->method('setVisitorId')->willReturnSelf();
+        $collectionMock->method('setVisibility')->willReturnSelf();
+        $collectionMock->method('addPriceData')->willReturnSelf();
+        $collectionMock->method('addAttributeToSelect')->willReturnSelf();
+        $collectionMock->method('addUrlRewrite')->willReturnSelf();
+        $collectionMock->method('load')->willReturnSelf();
+
+        $collectionMock->expects($this->once())
+            ->method('addOrder')
+            ->with('catalog_compare_item_id', 'ASC')
+            ->willReturnSelf();
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collectionMock);
+
+        $customerSession = $this->createMock(CustomerSession::class);
+        $customerSession->method('isLoggedIn')->willReturn(false);
+
+        $visitor = $this->createMock(Visitor::class);
+        $visitor->method('getId')->willReturn(1);
+
+        $storeMock = $this->createMock(\Magento\Store\Model\Store::class);
+        $storeMock->method('getId')->willReturn(1);
+        $storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
+        $storeManagerMock->method('getStore')->willReturn($storeMock);
+
+        $objectManager = new ObjectManager($this);
+        $helper = $objectManager->getObject(
+            Compare::class,
+            [
+                'itemCollectionFactory' => $collectionFactory,
+                'customerSession'       => $customerSession,
+                'customerVisitor'       => $visitor,
+                'storeManager'          => $storeManagerMock,
+            ]
+        );
+
+        $helper->getItemCollection();
     }
 }


### PR DESCRIPTION
### Description

The product compare list collection had no `ORDER BY` clause in either the Block or the Helper. Items appeared in database storage order, which is non-deterministic: the order depends on the DB engine's internal row storage and changes unpredictably after updates, deletes, or table optimizations.

A customer who adds Product A then Product B to the compare list has no guarantee they will appear in that order on the compare page.

#### Affected code paths

Both render the compare list independently:

- `Magento\Catalog\Block\Product\Compare\ListCompare::getItems()` — used by the compare page block
- `Magento\Catalog\Helper\Product\Compare::getItemCollection()` — used by the compare widget/sidebar

#### Fix

Added `->addOrder('catalog_compare_item_id', 'ASC')` to the collection in both methods. `catalog_compare_item_id` is the auto-increment primary key of the `catalog_compare_item` table, so items appear in the order they were added.

#### Verification

The generated SQL before the fix has no `ORDER BY` clause:

```sql
-- Before
SELECT ... FROM `catalog_compare_item` AS `t_compare` ... WHERE (...)
-- no ORDER BY

-- After
SELECT ... FROM `catalog_compare_item` AS `t_compare` ... WHERE (...)
ORDER BY `t_compare`.`catalog_compare_item_id` ASC
```

### Test results

```
Compare (Helper)
 ✔ Get post data remove
 ✔ Get clear list url
 ✔ Get post data clear list
 ✔ Get add to cart url
 ✔ Get item collection orders by compare item id ascending

List Compare (Block)
 ✔ Product attribute value with data set #0
 ✔ Product attribute value with data set #1
 ✔ Get product price
 ✔ Get items orders by compare item id ascending

OK (9 tests, 49 assertions)
```

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (all builds are green)