### PR TITLE
Allow optionConfig.selectFields to override hardcoded list in product-attributes.js

### DIFF
--- a/app/code/Magento/Swatches/view/adminhtml/web/js/product-attributes.js
+++ b/app/code/Magento/Swatches/view/adminhtml/web/js/product-attributes.js
@@ -47,7 +47,7 @@ define([
                 get tabsFront() {
                     return this.attrTabsFront.length ? this.attrTabsFront.closest('li') : $('#front_fieldset-wrapper');
                 },
-                selectFields: ['boolean', 'select', 'multiselect', 'price', 'swatch_text', 'swatch_visual'],
+                selectFields: optionConfig.selectFields || ['boolean', 'select', 'multiselect', 'price', 'swatch_text', 'swatch_visual'],
 
                 /**
                  * @this {swatchProductAttributes}


### PR DESCRIPTION
### Description

The `selectFields` list in `Magento_Swatches/js/product-attributes` was fully hardcoded:

```javascript
selectFields: ['boolean', 'select', 'multiselect', 'price', 'swatch_text', 'swatch_visual'],
```

This list controls which frontend input types enable the **Is Filterable** and **Is Filterable in Search** options on the attribute edit page. Any module adding a custom frontend input type that should behave like a select (e.g. a custom `my_select_variant` type) had no extension point — it had to patch this JS file directly.

#### Fix

Use `optionConfig.selectFields` if the caller provides it, falling back to the hardcoded list:

```diff
- selectFields: ['boolean', 'select', 'multiselect', 'price', 'swatch_text', 'swatch_visual'],
+ selectFields: optionConfig.selectFields || ['boolean', 'select', 'multiselect', 'price', 'swatch_text', 'swatch_visual'],
```

Default behaviour is entirely unchanged. Third-party modules can now pass a custom list via `optionConfig` without patching the core file.

### BC impact

None. The fallback to the hardcoded list means all existing integrations continue to work identically.

### Manual testing scenarios

1. Open any product attribute edit page — all existing types should behave as before
2. A third-party module can now pass `optionConfig.selectFields = ['boolean', 'select', 'my_custom_type']` and the attribute admin page will enable filterable options for `my_custom_type`

### Tests

No automated test is provided. `product-attributes.js` initialises against live adminhtml DOM elements at load time; the Jasmine test infrastructure in this repository does not cover adminhtml JS files. The change is a single-line `||` fallback with provably correct behaviour.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable) — no adminhtml JS test harness exists; gap noted
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (all builds are green)