### PR TITLE
Add getUrl() getter to Redirect result class

### DIFF
--- a/lib/internal/Magento/Framework/Controller/Result/Redirect.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Redirect.php
@@ -85,6 +85,16 @@ class Redirect extends AbstractResult
     }
 
     /**
+     * URL Getter
+     *
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return (string)$this->url;
+    }
+
+    /**
      * Set url by path
      *
      * @param string $path

--- a/lib/internal/Magento/Framework/Controller/Test/Unit/Result/RedirectTest.php
+++ b/lib/internal/Magento/Framework/Controller/Test/Unit/Result/RedirectTest.php
@@ -65,6 +65,31 @@ class RedirectTest extends TestCase
         $this->assertInstanceOf(Redirect::class, $this->redirect->setUrl($url));
     }
 
+    public function testGetUrlReturnsUrlSetViaSetUrl(): void
+    {
+        $url = 'https://example.com/catalog/product/view/id/1';
+        $this->redirect->setUrl($url);
+        $this->assertSame($url, $this->redirect->getUrl());
+    }
+
+    public function testGetUrlReturnsUrlSetViaSetPath(): void
+    {
+        $path   = 'catalog/product/view';
+        $params = ['id' => 1];
+        $expectedUrl = 'https://example.com/catalog/product/view/id/1';
+
+        $this->redirectInterface->method('updatePathParams')->with($params)->willReturn($params);
+        $this->urlInterface->method('getUrl')->with($path, $params)->willReturn($expectedUrl);
+
+        $this->redirect->setPath($path, $params);
+        $this->assertSame($expectedUrl, $this->redirect->getUrl());
+    }
+
+    public function testGetUrlReturnsEmptyStringWhenNotSet(): void
+    {
+        $this->assertSame('', $this->redirect->getUrl());
+    }
+
     public function testSetPath()
     {
         $path = 'test/path';


### PR DESCRIPTION
### Description

\`Magento\Framework\Controller\Result\Redirect\` has setters (\`setUrl()\`, \`setPath()\`, \`setRefererUrl()\`) but no getter. A plugin on any controller's \`execute()\` method that returns a \`Redirect\` cannot read back the destination URL to conditionally modify or log it.

```php
// common plugin pattern — impossible without getUrl()
public function afterExecute(SomeController $subject, $result)
{
    if ($result instanceof Redirect) {
        $url = $result->getUrl(); // was not available
        // inspect/modify/log the redirect destination
    }
    return $result;
}
```

#### Fix

Added a single public getter:

```php
public function getUrl(): string
{
    return (string)$this->url;
}
```

The cast to string safely handles the initial state where \`$this->url\` is null (returns \`''\`).

### BC impact

None — purely additive.

### Test results

```
Redirect (Magento\Framework\Controller\Test\Unit\Result\Redirect)
 ✔ Set referer url
 ✔ Set referer or base url
 ✔ Set url
 ✔ Get url returns url set via set url
 ✔ Get url returns url set via set path
 ✔ Get url returns empty string when not set
 ✔ Set path
 ✔ Render with data set #0 / #1 / #2

OK (10 tests, 23 assertions)
```

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (all builds are green)