### PR TITLE
Use configurable cookie path in customer-data.js initStorage

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -239,7 +239,7 @@ define([
          */
         initStorage: function () {
             $.cookieStorage.setConf({
-                path: '/',
+                path: options.cookiePath || '/',
                 expires: new Date(Date.now() + parseInt(options.cookieLifeTime, 10) * 1000)
             });
 

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Customer/frontend/js/customer-data.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Customer/frontend/js/customer-data.test.js
@@ -564,5 +564,46 @@ define([
                 expect($.localStorage.get).toHaveBeenCalledWith('mage-customer-login');
             });
         });
+
+        describe('"initStorage" cookie path', function () {
+            var originalCookieStorage,
+                originalLocalStorage,
+                cookieStorageSpy;
+
+            beforeEach(function () {
+                originalCookieStorage = $.cookieStorage;
+                originalLocalStorage  = $.localStorage;
+
+                cookieStorageSpy = jasmine.createSpyObj(
+                    'cookieStorage', ['setConf', 'set', 'get', 'isSet']
+                );
+                cookieStorageSpy.get.and.returnValue({});
+                cookieStorageSpy.isSet.and.returnValue(false);
+
+                $.cookieStorage = cookieStorageSpy;
+                $.localStorage  = jasmine.createSpyObj(
+                    'localStorage', ['isSet', 'get', 'set']
+                );
+            });
+
+            afterEach(function () {
+                $.cookieStorage = originalCookieStorage;
+                $.localStorage  = originalLocalStorage;
+            });
+
+            it('uses "/" as default cookie path when cookiePath is not configured', function () {
+                init({ cookieLifeTime: 3600 });
+                expect(cookieStorageSpy.setConf).toHaveBeenCalledWith(
+                    jasmine.objectContaining({ path: '/' })
+                );
+            });
+
+            it('uses the configured cookiePath when provided', function () {
+                init({ cookieLifeTime: 3600, cookiePath: '/shop/' });
+                expect(cookieStorageSpy.setConf).toHaveBeenCalledWith(
+                    jasmine.objectContaining({ path: '/shop/' })
+                );
+            });
+        });
     });
 });


### PR DESCRIPTION
### Description

`customer-data.js::initStorage()` hardcoded `path: '/'` when configuring cookie storage:

```javascript
$.cookieStorage.setConf({
    path: '/',   // ← hardcoded
    expires: ...
});
```

Stores deployed at a sub-path (e.g. `example.com/shop/`) need a matching cookie path. With a hardcoded `'/'`, customer section cookies are scoped to the root domain, which can cause:

- Cookie conflicts when multiple Magento stores run at different paths on the same domain
- Customer section data leaking across stores
- Inability to correctly scope cookies in sub-path deployments

#### Fix

```diff
- path: '/',
+ path: options.cookiePath || '/',
```

Default behaviour is **unchanged** — `options.cookiePath` is only active if the backend explicitly provides it in the settings block. Without it the path remains `'/'`.

### Test results

```
"initStorage" cookie path
  - uses "/" as default cookie path when cookiePath is not configured......✓
  - uses the configured cookiePath when provided......✓

30 specs in 0.251s.
>> 0 failures
```

> **Note:** The Jasmine test infrastructure is not wired into CI. Tests were verified locally and results are posted here.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated — N/A
- [x] All automated tests passed successfully (all builds are green)