### PR TITLE
fix(installer): write 'redis' backend type instead of Cm_Cache_Backend_Redis

### DIFF
--- a/setup/src/MageOS/Installer/Model/Writer/EnvConfigWriter.php
+++ b/setup/src/MageOS/Installer/Model/Writer/EnvConfigWriter.php
@@ -76,7 +76,7 @@ class EnvConfigWriter
                 $config['cache'] = [
                     'frontend' => [
                         'default' => [
-                            'backend' => 'Cm_Cache_Backend_Redis',
+                            'backend' => 'redis',
                             'backend_options' => [
                                 'server' => $host,
                                 'port' => (string)$port,
@@ -104,7 +104,7 @@ class EnvConfigWriter
                     $config['cache'] = ['frontend' => []];
                 }
                 $config['cache']['frontend']['page_cache'] = [
-                    'backend' => 'Cm_Cache_Backend_Redis',
+                    'backend' => 'redis',
                     'backend_options' => [
                         'server' => $host,
                         'port' => (string)$port,
@@ -156,7 +156,7 @@ class EnvConfigWriter
                 $config['cache'] = [
                     'frontend' => [
                         'default' => [
-                            'backend' => 'Cm_Cache_Backend_Redis',
+                            'backend' => 'redis',
                             'backend_options' => [
                                 'server' => $redisConfig['cache']['host'],
                                 'port' => $redisConfig['cache']['port'],
@@ -180,7 +180,7 @@ class EnvConfigWriter
                 // FPC configuration
                 if ($redisConfig['fpc'] && $redisConfig['fpc']['enabled']) {
                     $config['cache']['frontend']['page_cache'] = [
-                        'backend' => 'Cm_Cache_Backend_Redis',
+                        'backend' => 'redis',
                         'backend_options' => [
                             'server' => $redisConfig['fpc']['host'],
                             'port' => $redisConfig['fpc']['port'],

--- a/setup/tests/unit/MageOS/Installer/Model/Writer/EnvConfigWriterTest.php
+++ b/setup/tests/unit/MageOS/Installer/Model/Writer/EnvConfigWriterTest.php
@@ -73,7 +73,7 @@ class EnvConfigWriterTest extends TestCase
                 $this->callback(function ($config) {
                     $envConfig = $config[ConfigFilePool::APP_ENV];
                     return isset($envConfig['cache']['frontend']['default'])
-                        && $envConfig['cache']['frontend']['default']['backend'] === 'Cm_Cache_Backend_Redis'
+                        && $envConfig['cache']['frontend']['default']['backend'] === 'redis'
                         && $envConfig['cache']['frontend']['default']['backend_options']['database'] === '1';
                 }),
                 true
@@ -99,7 +99,7 @@ class EnvConfigWriterTest extends TestCase
                 $this->callback(function ($config) {
                     $envConfig = $config[ConfigFilePool::APP_ENV];
                     return isset($envConfig['cache']['frontend']['page_cache'])
-                        && $envConfig['cache']['frontend']['page_cache']['backend'] === 'Cm_Cache_Backend_Redis'
+                        && $envConfig['cache']['frontend']['page_cache']['backend'] === 'redis'
                         && $envConfig['cache']['frontend']['page_cache']['backend_options']['database'] === '2';
                 }),
                 true


### PR DESCRIPTION
## Summary

- `EnvConfigWriter` wrote `'backend' => 'Cm_Cache_Backend_Redis'` in 4 places (both the flat VO path and the nested collector/legacy path)
- After AC-15351, all cache backends route through `SymfonyAdapterProvider`, which maps known type strings (`'redis'`, `'valkey'`, `'file'`, …) to Symfony adapters
- `'Cm_Cache_Backend_Redis'` is not in `SymfonyAdapterProvider::$adapterTypeMap` and silently falls back to the **filesystem adapter**, bypassing Redis entirely on every fresh install via the interactive installer

## Fix

Change all 4 occurrences of `'Cm_Cache_Backend_Redis'` → `'redis'` in `setup/src/MageOS/Installer/Model/Writer/EnvConfigWriter.php`.

`'redis'` is the correct type string recognised by `SymfonyAdapterProvider::$adapterTypeMap` (introduced in AC-15351).

## Test plan

- [ ] Run interactive installer with Redis cache enabled — verify `env.php` contains `'backend' => 'redis'`
- [ ] Confirm cache entries are written to Redis (not `var/cache/`) after install
- [ ] Verify both flat (VO) and nested (legacy collector) code paths produce `'backend' => 'redis'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)