### PR TITLE
Support a Unix-socket db-host in integration tests

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
@@ -70,6 +70,13 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
     private $_port;
 
     /**
+     * Unix socket path for connection, when the configured host is a path
+     *
+     * @var string
+     */
+    private $_socket = '';
+
+    /**
      * @var bool
      */
     private $isMysqldumpVersion8;
@@ -98,7 +105,12 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
     {
         parent::__construct($host, $user, $password, $schema, $varPath, $shell);
         $this->_port = self::DEFAULT_PORT;
-        if (strpos($this->_host, ':') !== false) {
+        if (strpos($this->_host, '/') !== false) {
+            // A path means a Unix socket, mirroring the db-host convention
+            // of \Magento\Framework\DB\Adapter\Pdo\Mysql.
+            $this->_socket = $this->_host;
+            $this->_host = 'localhost';
+        } elseif (strpos($this->_host, ':') !== false) {
             list($host, $port) = explode(':', $this->_host);
             $this->_host = $host;
             $this->_port = (int) $port;
@@ -116,14 +128,15 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
 
         $this->ensureDefaultsExtraFile();
         $this->_shell->execute(
-            "{$dbCommand} --defaults-file=%s --host=%s --port=%s %s -e %s",
-            [
-                $this->_defaultsExtraFile,
-                $this->_host,
-                $this->_port,
-                $this->_schema,
-                "DROP DATABASE `{$this->_schema}`; CREATE DATABASE `{$this->_schema}`"
-            ]
+            "{$dbCommand} --defaults-file=%s {$this->getEndpointFormat()} %s -e %s",
+            array_merge(
+                [$this->_defaultsExtraFile],
+                $this->getEndpointArguments(),
+                [
+                    $this->_schema,
+                    "DROP DATABASE `{$this->_schema}`; CREATE DATABASE `{$this->_schema}`"
+                ]
+            )
         );
     }
 
@@ -166,7 +179,7 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
 
         $format = sprintf(
             '%s %s %s %s',
-            "{$dumpCommand} --defaults-file=%s --host=%s --port=%s",
+            "{$dumpCommand} --defaults-file=%s {$this->getEndpointFormat()}",
             '--no-tablespaces',
             implode(' ', $additionalArguments),
             '%s > %s'
@@ -174,13 +187,14 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
 
         $this->_shell->execute(
             $format,
-            [
-                $this->_defaultsExtraFile,
-                $this->_host,
-                $this->_port,
-                $this->_schema,
-                $this->getSetupDbDumpFilename()
-            ]
+            array_merge(
+                [$this->_defaultsExtraFile],
+                $this->getEndpointArguments(),
+                [
+                    $this->_schema,
+                    $this->getSetupDbDumpFilename()
+                ]
+            )
         );
     }
 
@@ -199,9 +213,12 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
         $dbCommand = $this->getDbCommand();
 
         $this->_shell->execute(
-            "{$dbCommand} --defaults-file=%s --host=%s --port=%s %s < %s",
-            [$this->_defaultsExtraFile, $this->_host, $this->_port,
-                $this->_schema, $this->getSetupDbDumpFilename()]
+            "{$dbCommand} --defaults-file=%s {$this->getEndpointFormat()} %s < %s",
+            array_merge(
+                [$this->_defaultsExtraFile],
+                $this->getEndpointArguments(),
+                [$this->_schema, $this->getSetupDbDumpFilename()]
+            )
         );
     }
 
@@ -211,6 +228,28 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
     public function getVendorName()
     {
         return 'mysql';
+    }
+
+    /**
+     * Endpoint format fragment for the mysql/mariadb CLI tools
+     *
+     * Yields --socket=%s for a Unix socket path, --host=%s --port=%s otherwise.
+     *
+     * @return string
+     */
+    private function getEndpointFormat()
+    {
+        return $this->_socket !== '' ? '--socket=%s' : '--host=%s --port=%s';
+    }
+
+    /**
+     * Endpoint arguments matching getEndpointFormat()
+     *
+     * @return array
+     */
+    private function getEndpointArguments()
+    {
+        return $this->_socket !== '' ? [$this->_socket] : [$this->_host, $this->_port];
     }
 
     /**
@@ -261,13 +300,13 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
         if (!isset($this->isUsingAuroraDb)) {
             try {
                 $this->_shell->execute(
-                    'mysql --defaults-file=%s --host=%s --port=%s %s --execute="SELECT AURORA_VERSION()"',
-                    [
-                        $this->_defaultsExtraFile,
-                        $this->_host,
-                        $this->_port,
-                        $this->_schema
-                    ]
+                    'mysql --defaults-file=%s ' . $this->getEndpointFormat()
+                        . ' %s --execute="SELECT AURORA_VERSION()"',
+                    array_merge(
+                        [$this->_defaultsExtraFile],
+                        $this->getEndpointArguments(),
+                        [$this->_schema]
+                    )
                 );
 
                 $this->isUsingAuroraDb = true;

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -523,7 +523,10 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface, Rese
 
         if (strpos($this->_config['host'], '/') !== false) {
             $this->_config['unix_socket'] = $this->_config['host'];
-            unset($this->_config['host']);
+            // Keep a host in the config: mysqlnd routes "localhost" through
+            // unix_socket, and unsetting the key made every reconnect on the
+            // same adapter throw "No host configured to connect".
+            $this->_config['host'] = 'localhost';
         } elseif (strpos($this->_config['host'], ':') !== false) {
             list($this->_config['host'], $this->_config['port']) = explode(':', $this->_config['host']);
         }


### PR DESCRIPTION
Running the integration test suite against a MySQL/MariaDB server that listens only on a Unix socket does not work today, even though the application itself supports it (`Magento\Framework\DB\Adapter\Pdo\Mysql::_connect()` treats a `db-host` containing `/` as a socket path). Two things break:

1. **`Magento\TestFramework\Db\Mysql`** passes the configured `db-host` verbatim to the `mysql`/`mariadb` CLI tools as `--host`, always together with an explicit `--port`. A socket path is not a hostname, and an explicit `--port` makes MariaDB clients insist on TCP — so the setup DB dump (`storeDbDump`), `cleanup()` and `restoreFromDbDump()` all fail against a socket-only server. This PR makes those invocations use `--socket=` when `db-host` is a socket path, mirroring the PDO adapter's convention.

2. **`Magento\Framework\DB\Adapter\Pdo\Mysql::_connect()`** moves the socket path into `$config['unix_socket']` and then `unset`s `$config['host']` — the config mutation means any *reconnect* on the same adapter instance (`closeConnection()` + a later query, which several integration tests trigger) throws `No host configured to connect`. The fix keeps `host = 'localhost'` alongside `unix_socket`; mysqlnd routes that combination through the socket, and reconnects find a valid config.

### Testing

Against MariaDB 11.4 listening on a socket only, with `'db-host' => '/path/to/mariadb.sock'` in `dev/tests/integration/etc/install-config-mysql.php`:

- Before: bootstrap fails at the DB dump step (the CLI tool receives the socket path as `--host`), and — worked around — reconnecting tests fail with `No host configured to connect`.
- After: `testsuite/Magento/Directory` passes (246 tests, 464 assertions, 0 failures), verified on a Mage-OS 3.1 project.

### Related

- Same change submitted upstream: magento/magento2#40943