### PR TITLE
Decouple Magento_Customer from Magento_Wishlist: move new-account-email plugin registration

### DIFF
--- a/app/code/Magento/Customer/etc/di.xml
+++ b/app/code/Magento/Customer/etc/di.xml
@@ -568,9 +568,6 @@
             </argument>
         </arguments>
     </type>
-    <type name="Magento\Customer\Model\EmailNotificationInterface">
-        <plugin name="saveWishlistDataAndAddReferenceKeyToBackUrl" type="Magento\Wishlist\Plugin\SaveWishlistDataAndAddReferenceKeyToBackUrl"/>
-    </type>
     <type name="Magento\Eav\Model\Validator\Attribute\Data">
         <arguments>
             <argument name="ignoredAttributesByTypesList" xsi:type="array">

--- a/app/code/Magento/Wishlist/etc/di.xml
+++ b/app/code/Magento/Wishlist/etc/di.xml
@@ -71,6 +71,9 @@
     <type name="Magento\Catalog\Ui\DataProvider\Product\Listing\DataProvider">
         <plugin name="wishlistSettingsDataProvider" type="Magento\Wishlist\Plugin\Ui\DataProvider\WishlistSettings"/>
     </type>
+    <type name="Magento\Customer\Model\EmailNotificationInterface">
+        <plugin name="saveWishlistDataAndAddReferenceKeyToBackUrl" type="Magento\Wishlist\Plugin\SaveWishlistDataAndAddReferenceKeyToBackUrl"/>
+    </type>
     <type name="Magento\Catalog\Ui\DataProvider\Product\ProductRenderCollectorComposite">
         <arguments>
             <argument name="productProviders" xsi:type="array">


### PR DESCRIPTION
### Description (*)

Moves the `saveWishlistDataAndAddReferenceKeyToBackUrl` plugin registration from `Customer/etc/di.xml` into `Wishlist/etc/di.xml` — the plugin class lives in Magento_Wishlist, and registering it in Magento_Customer makes `setup:di:compile` fail when module-wishlist is removed. Same global area, so no behavior change; first slice of a series making Magento_Wishlist fully removable.

### Related Pull Requests

None yet — this is part of the Modulargento project (making sure modules can be added/removed)

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios (*)

1. Regression: as a guest, add a product to the wishlist and register (with *Require Emails Confirmation* enabled) — the confirmation link still carries the wishlist `referenceKey` and the item lands in the wishlist after confirming. `bin/magento dev:di:info 'Magento\Customer\Model\EmailNotificationInterface'` still lists the plugin.
2. Decoupling: with `magento/module-wishlist` (and dependents) removed, `bin/magento setup:di:compile` no longer fails on the missing plugin class.

### Questions or comments

Kept the registration in the global area for exact parity; arguably it belongs in `frontend` only (the plugin uses the frontend customer session), but that would be a behavior change. Happy to add an integration test asserting the plugin is in the interception config if wanted.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable — pure di.xml move, covered by static integrity suite)
 - [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update (none required)
 - [ ] All automated tests passed successfully (all builds are green)
