### PR TITLE
Decouple the admin order-create items grid from Magento_Wishlist

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Items/Grid.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Items/Grid.php
@@ -35,7 +35,10 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
     protected $_taxData;
 
     /**
-     * @var \Magento\Wishlist\Model\WishlistFactory
+     * Supplied through di.xml by Magento_Wishlist while that module is present;
+     * null otherwise, in which case the grid offers no move-to-wishlist actions.
+     *
+     * @var \Magento\Wishlist\Model\WishlistFactory|null
      */
     protected $_wishlistFactory;
 
@@ -69,7 +72,7 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
      * @param \Magento\Backend\Model\Session\Quote $sessionQuote
      * @param \Magento\Sales\Model\AdminOrder\Create $orderCreate
      * @param PriceCurrencyInterface $priceCurrency
-     * @param \Magento\Wishlist\Model\WishlistFactory $wishlistFactory
+     * @param \Magento\Wishlist\Model\WishlistFactory|null $wishlistFactory
      * @param \Magento\GiftMessage\Model\Save $giftMessageSave
      * @param \Magento\Tax\Model\Config $taxConfig
      * @param \Magento\Tax\Helper\Data $taxData
@@ -85,7 +88,7 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
         \Magento\Backend\Model\Session\Quote $sessionQuote,
         \Magento\Sales\Model\AdminOrder\Create $orderCreate,
         PriceCurrencyInterface $priceCurrency,
-        \Magento\Wishlist\Model\WishlistFactory $wishlistFactory,
+        $wishlistFactory,
         \Magento\GiftMessage\Model\Save $giftMessageSave,
         \Magento\Tax\Model\Config $taxConfig,
         \Magento\Tax\Helper\Data $taxData,
@@ -567,16 +570,22 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
      */
     public function isMoveToWishlistAllowed($item)
     {
-        return $item->getProduct()->isVisibleInSiteVisibility();
+        return $this->_wishlistFactory !== null && $item->getProduct()->isVisibleInSiteVisibility();
     }
 
     /**
-     * Retrieve collection of customer wishlists
+     * Retrieve customer wishlists
      *
-     * @return \Magento\Wishlist\Model\ResourceModel\Wishlist\Collection
+     * Returns \Magento\Wishlist\Model\ResourceModel\Wishlist\Collection when
+     * Magento_Wishlist is present, an empty iterable otherwise.
+     *
+     * @return iterable
      */
     public function getCustomerWishlists()
     {
+        if ($this->_wishlistFactory === null) {
+            return [];
+        }
         return $this->_wishlistFactory->create()->getCollection()->filterByCustomerId($this->getCustomerId());
     }
 

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Items/Grid.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Items/Grid.php
@@ -11,6 +11,7 @@ use Magento\CatalogInventory\Api\StockStateInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Framework\Session\SessionManagerInterface;
+use Magento\Framework\Module\Manager as ModuleManager;
 use Magento\Quote\Model\Quote\Item;
 use Magento\Catalog\Helper\Data as CatalogHelper;
 
@@ -35,8 +36,8 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
     protected $_taxData;
 
     /**
-     * Supplied through di.xml by Magento_Wishlist while that module is present;
-     * null otherwise, in which case the grid offers no move-to-wishlist actions.
+     * Null when Magento_Wishlist is not enabled, in which case the grid offers
+     * no move-to-wishlist actions.
      *
      * @var \Magento\Wishlist\Model\WishlistFactory|null
      */
@@ -81,6 +82,7 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
      * @param StockStateInterface $stockState
      * @param array $data
      * @param CatalogHelper|null $catalogHelper
+     * @param ModuleManager|null $moduleManager
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -96,10 +98,17 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
         StockRegistryInterface $stockRegistry,
         StockStateInterface $stockState,
         array $data = [],
-        ?CatalogHelper $catalogHelper = null
+        ?CatalogHelper $catalogHelper = null,
+        ?ModuleManager $moduleManager = null
     ) {
         $this->_messageHelper = $messageHelper;
-        $this->_wishlistFactory = $wishlistFactory;
+        // The wishlist factory cannot be a typed constructor dependency: di:compile
+        // fails on the typehint when module-wishlist is absent, and PHP forbids a
+        // default value at this position. Resolve it here while the module is enabled.
+        $moduleManager = $moduleManager ?? ObjectManager::getInstance()->get(ModuleManager::class);
+        $this->_wishlistFactory = $wishlistFactory ?? ($moduleManager->isEnabled('Magento_Wishlist')
+            ? ObjectManager::getInstance()->get(\Magento\Wishlist\Model\WishlistFactory::class)
+            : null);
         $this->_giftMessageSave = $giftMessageSave;
         $this->_taxConfig = $taxConfig;
         $this->_taxData = $taxData;

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/Items/GridTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/Items/GridTest.php
@@ -18,6 +18,7 @@ use Magento\CatalogInventory\Model\StockState;
 use Magento\Directory\Helper\Data as DirectoryHelper;
 use Magento\Framework\DataObject;
 use Magento\Framework\Json\Helper\Data as JsonHelper;
+use Magento\Framework\Module\Manager as ModuleManager;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\Element\AbstractBlock;
@@ -457,12 +458,63 @@ class GridTest extends TestCase
     }
 
     /**
-     * Without an injected wishlist factory the grid offers no wishlists.
+     * With Magento_Wishlist not enabled the grid offers no wishlists.
      */
-    public function testNoWishlistsWithoutWishlistFactory()
+    public function testNoWishlistsWithoutWishlistModule()
     {
-        $this->assertSame([], $this->block->getCustomerWishlists());
-        $this->assertFalse($this->block->isMoveToWishlistAllowed($this->createMock(Item::class)));
+        $moduleManager = $this->createMock(ModuleManager::class);
+        $moduleManager->method('isEnabled')->with('Magento_Wishlist')->willReturn(false);
+
+        $block = $this->objectManager->getObject(
+            Grid::class,
+            [
+                'wishlistFactory' => null,
+                'moduleManager' => $moduleManager,
+                'sessionQuote' => $this->createPartialMockWithReflection(Quote::class, ['getCustomerId']),
+            ]
+        );
+
+        $this->assertSame([], $block->getCustomerWishlists());
+        $this->assertFalse($block->isMoveToWishlistAllowed($this->createMock(Item::class)));
+    }
+
+    /**
+     * With Magento_Wishlist enabled the factory is resolved from the object
+     * manager (it cannot be a typed constructor dependency).
+     */
+    public function testWishlistFactoryResolvedWhenModuleEnabled()
+    {
+        $collection = $this->createPartialMockWithReflection(
+            \Magento\Wishlist\Model\ResourceModel\Wishlist\Collection::class,
+            ['filterByCustomerId']
+        );
+        $collection->method('filterByCustomerId')->willReturnSelf();
+        $wishlist = $this->createPartialMockWithReflection(
+            \Magento\Wishlist\Model\Wishlist::class,
+            ['getCollection']
+        );
+        $wishlist->method('getCollection')->willReturn($collection);
+        $wishlistFactory = $this->createPartialMockWithReflection(WishlistFactory::class, ['create']);
+        $wishlistFactory->method('create')->willReturn($wishlist);
+
+        $moduleManager = $this->createMock(ModuleManager::class);
+        $moduleManager->method('isEnabled')->with('Magento_Wishlist')->willReturn(true);
+        $this->objectManager->prepareObjectManager([
+            [WishlistFactory::class, $wishlistFactory],
+            [JsonHelper::class, $this->createMock(JsonHelper::class)],
+            [DirectoryHelper::class, $this->createMock(DirectoryHelper::class)],
+        ]);
+
+        $block = $this->objectManager->getObject(
+            Grid::class,
+            [
+                'wishlistFactory' => null,
+                'moduleManager' => $moduleManager,
+                'sessionQuote' => $this->createPartialMockWithReflection(Quote::class, ['getCustomerId']),
+            ]
+        );
+
+        $this->assertSame($collection, $block->getCustomerWishlists());
     }
 
     /**
@@ -500,4 +552,5 @@ class GridTest extends TestCase
         $item->method('getProduct')->willReturn($product);
         $this->assertTrue($block->isMoveToWishlistAllowed($item));
     }
+
 }

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/Items/GridTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/Items/GridTest.php
@@ -97,10 +97,7 @@ class GridTest extends TestCase
         $this->priceCurrency = $this->getMockBuilder(
             PriceCurrencyInterface::class
         )->getMock();
-        $sessionMock = $this->getMockBuilder(Quote::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getQuote'])
-            ->getMock();
+        $sessionMock = $this->createPartialMockWithReflection(Quote::class, ['getQuote', 'getCustomerId']);
 
         $quoteMock = $this->getMockBuilder(QuoteModel::class)
             ->disableOriginalConstructor()
@@ -113,7 +110,6 @@ class GridTest extends TestCase
             ->willReturnArgument(0);
         $quoteMock->expects($this->any())->method('getStore')->willReturn($storeMock);
         $sessionMock->expects($this->any())->method('getQuote')->willReturn($quoteMock);
-        $wishlistFactoryMock = $this->createPartialMockWithReflection(WishlistFactory::class, ['methods']);
 
         $giftMessageSave = $this->createMock(GiftMessageSave::class);
 
@@ -153,7 +149,7 @@ class GridTest extends TestCase
         $this->block = $this->objectManager->getObject(
             Grid::class,
             [
-                'wishlistFactory' => $wishlistFactoryMock,
+                'wishlistFactory' => null,
                 'giftMessageSave' => $giftMessageSave,
                 'taxConfig' => $taxConfig,
                 'taxData' => $taxData,
@@ -458,5 +454,50 @@ class GridTest extends TestCase
             'expected' => 32
         ];
         return $result;
+    }
+
+    /**
+     * Without an injected wishlist factory the grid offers no wishlists.
+     */
+    public function testNoWishlistsWithoutWishlistFactory()
+    {
+        $this->assertSame([], $this->block->getCustomerWishlists());
+        $this->assertFalse($this->block->isMoveToWishlistAllowed($this->createMock(Item::class)));
+    }
+
+    /**
+     * With the wishlist factory injected (done by Magento_Wishlist through
+     * di.xml), wishlists resolve exactly as before.
+     */
+    public function testGetCustomerWishlistsUsesInjectedWishlistFactory()
+    {
+        $collection = $this->createPartialMockWithReflection(
+            \Magento\Wishlist\Model\ResourceModel\Wishlist\Collection::class,
+            ['filterByCustomerId']
+        );
+        $collection->expects($this->once())->method('filterByCustomerId')->willReturnSelf();
+        $wishlist = $this->createPartialMockWithReflection(
+            \Magento\Wishlist\Model\Wishlist::class,
+            ['getCollection']
+        );
+        $wishlist->method('getCollection')->willReturn($collection);
+        $wishlistFactory = $this->createPartialMockWithReflection(WishlistFactory::class, ['create']);
+        $wishlistFactory->method('create')->willReturn($wishlist);
+
+        $block = $this->objectManager->getObject(
+            Grid::class,
+            [
+                'wishlistFactory' => $wishlistFactory,
+                'sessionQuote' => $this->createPartialMockWithReflection(Quote::class, ['getCustomerId']),
+            ]
+        );
+
+        $this->assertSame($collection, $block->getCustomerWishlists());
+
+        $product = $this->createMock(Product::class);
+        $product->method('isVisibleInSiteVisibility')->willReturn(true);
+        $item = $this->createMock(Item::class);
+        $item->method('getProduct')->willReturn($product);
+        $this->assertTrue($block->isMoveToWishlistAllowed($item));
     }
 }

--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -1090,4 +1090,10 @@
             <argument name="batchSize" xsi:type="number">5000</argument>
         </arguments>
     </type>
+    <type name="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid">
+        <arguments>
+            <!-- Overridden with the real factory by Magento_Wishlist's adminhtml di.xml -->
+            <argument name="wishlistFactory" xsi:type="null"/>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -1092,7 +1092,8 @@
     </type>
     <type name="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid">
         <arguments>
-            <!-- Overridden with the real factory by Magento_Wishlist's adminhtml di.xml -->
+            <!-- The parameter can be neither typehinted nor given a PHP default (see the
+                 constructor, which resolves the factory while Magento_Wishlist is enabled). -->
             <argument name="wishlistFactory" xsi:type="null"/>
         </arguments>
     </type>

--- a/app/code/Magento/Wishlist/etc/adminhtml/di.xml
+++ b/app/code/Magento/Wishlist/etc/adminhtml/di.xml
@@ -26,4 +26,9 @@
     </type>
     <preference for="Magento\Wishlist\Model\ResourceModel\Item\Product\CollectionBuilderInterface"
                 type="Magento\Wishlist\Model\Adminhtml\ResourceModel\Item\Product\CollectionBuilder"/>
+    <type name="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid">
+        <arguments>
+            <argument name="wishlistFactory" xsi:type="object">Magento\Wishlist\Model\WishlistFactory</argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/Wishlist/etc/adminhtml/di.xml
+++ b/app/code/Magento/Wishlist/etc/adminhtml/di.xml
@@ -26,9 +26,4 @@
     </type>
     <preference for="Magento\Wishlist\Model\ResourceModel\Item\Product\CollectionBuilderInterface"
                 type="Magento\Wishlist\Model\Adminhtml\ResourceModel\Item\Product\CollectionBuilder"/>
-    <type name="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid">
-        <arguments>
-            <argument name="wishlistFactory" xsi:type="object">Magento\Wishlist\Model\WishlistFactory</argument>
-        </arguments>
-    </type>
 </config>

--- a/app/code/Magento/Wishlist/etc/module.xml
+++ b/app/code/Magento/Wishlist/etc/module.xml
@@ -11,6 +11,7 @@
             <module name="Magento_Customer"/>
             <module name="Magento_Catalog"/>
             <module name="Magento_Captcha"/>
+            <module name="Magento_Sales"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
### Description (*)

`Sales\Block\Adminhtml\Order\Create\Items\Grid` takes `Magento\Wishlist\Model\WishlistFactory` as a required, typed constructor argument, so `setup:di:compile` fails for Magento_Sales when module-wishlist is removed. Untype the parameter in place (position kept, so subclasses calling `parent::__construct` are unaffected) and resolve the factory in the constructor instead, gated on `Module\Manager::isEnabled('Magento_Wishlist')`; without the module the grid's "Move to Wish List" actions simply don't render. Second slice of the series making Magento_Wishlist fully removable (see #286).

### Related Pull Requests

mage-os/mageos-magento2#286

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios (*)

1. Regression: in the admin, create an order for a customer who has wishlist items — the items grid's *Move to* action still offers "Move to Wish List" and moving an item works as before.
2. Decoupling: with `magento/module-wishlist` (and dependents) removed, `bin/magento setup:di:compile` passes and the order-create page renders without the wishlist option.
3. Unit: `GridTest` now covers both states (previously it stubbed a nonexistent factory method).

### Questions or comments

- The parameter is untyped with no default on purpose: the typehint is what breaks `setup:di:compile` (its factory scanner reports a configuration error for factories of absent classes), and every `= null` form before required parameters is deprecated on PHP 8.4 (`?Type $x = null` since PHP 8.0). The `xsi:type="null"` in Sales' di.xml is the parameter's effective default — required so the untyped parameter stays resolvable in developer mode.
- `Sales/composer.json` still requires `magento/module-wishlist`: the remaining couplings (`Order\Create\Sidebar\Wishlist` block, `Model\AdminOrder\Create`, the `WishlistDataCleanUp` data patch) are planned as follow-up slices, and the require should only drop with the last of them.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update (none required)
 - [ ] All automated tests passed successfully (all builds are green)
