### PR TITLE
Fix `MvcApplication` GLOB_BRACE reference for musl/Alpine PHP

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Mvc/MvcApplication.php
+++ b/lib/internal/Magento/Framework/Setup/Mvc/MvcApplication.php
@@ -10,6 +10,7 @@ namespace Magento\Framework\Setup\Mvc;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Stdlib\ArrayUtils;
+use Magento\Framework\Filesystem\Glob;
 
 /**
  * Native MVC Application that replicates Laminas\Mvc\Application functionality
@@ -167,7 +168,7 @@ class MvcApplication
         // Load global.php and local.php configurations from config_glob_paths
         if (isset($configuration['module_listener_options']['config_glob_paths'])) {
             foreach ($configuration['module_listener_options']['config_glob_paths'] as $globPath) {
-                $files = glob($globPath, GLOB_BRACE);
+                $files = Glob::glob($globPath, Glob::GLOB_BRACE);
                 foreach ($files as $file) {
                     if (is_readable($file)) {
                         $autoloadConfig = include $file;

--- a/lib/internal/Magento/Framework/Setup/Mvc/MvcApplication.php
+++ b/lib/internal/Magento/Framework/Setup/Mvc/MvcApplication.php
@@ -10,7 +10,7 @@ namespace Magento\Framework\Setup\Mvc;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Stdlib\ArrayUtils;
-use Magento\Framework\Filesystem\Glob;
+use Magento\Framework\Filesystem\Glob as GlobWrapper;
 
 /**
  * Native MVC Application that replicates Laminas\Mvc\Application functionality
@@ -168,7 +168,7 @@ class MvcApplication
         // Load global.php and local.php configurations from config_glob_paths
         if (isset($configuration['module_listener_options']['config_glob_paths'])) {
             foreach ($configuration['module_listener_options']['config_glob_paths'] as $globPath) {
-                $files = Glob::glob($globPath, Glob::GLOB_BRACE);
+                $files = GlobWrapper::glob($globPath, GlobWrapper::GLOB_BRACE);
                 foreach ($files as $file) {
                     if (is_readable($file)) {
                         $autoloadConfig = include $file;


### PR DESCRIPTION
### Problem
Mage-OS 3.1.0/Magento 2.4.9 introduced `Magento\Framework\Setup\Mvc\MvcApplication`, whose `loadAutoloadConfig()` calls `glob($globPath, GLOB_BRACE)` with the bare PHP constant. The `check-store` GitHub Actions smoke-test job runs PHP in `mappia/magento-php:fpm-alpine8.x` (musl libc), where `GLOB_BRACE` is undefined.

`MvcApplication::init()` runs on every `bin/magento` bootstrap via `Console\Cli`, so bootstrap throws `Undefined constant GLOB_BRACE` and *every* CLI command fatals -- `setup:install` first, failing the smoke-test job (CI run 459 / job 587). glibc jobs (unit-test, coding-standard) don't hit `setup:install`, so only smoke-test breaks.

### Fix
Route through `Magento\Framework\Filesystem\Glob::glob()`, the portable wrapper already used elsewhere in the framework: native `GLOB_BRACE` on glibc, pure-PHP brace-expansion fallback on musl. No bare constant reference.

```diff
+use Magento\Framework\Filesystem\Glob;
...
-                $files = glob($globPath, GLOB_BRACE);
+                $files = Glob::glob($globPath, Glob::GLOB_BRACE);
```
