### PR TITLE
Apply Adobe isolated security patch 249-2026-07-001 (CE)

### DIFF
--- a/app/code/Magento/AsyncConfig/Model/AsyncConfigPublisher.php
+++ b/app/code/Magento/AsyncConfig/Model/AsyncConfigPublisher.php
@@ -7,14 +7,16 @@ declare(strict_types=1);
 
 namespace Magento\AsyncConfig\Model;
 
+use Magento\AsyncConfig\Api\AsyncConfigPublisherInterface;
 use Magento\AsyncConfig\Api\Data\AsyncConfigMessageInterfaceFactory;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem\Io\File;
 use Magento\Framework\MessageQueue\PublisherInterface;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Filesystem\DirectoryList as FilesystemDirectoryList;
 
-class AsyncConfigPublisher implements \Magento\AsyncConfig\Api\AsyncConfigPublisherInterface
+class AsyncConfigPublisher implements AsyncConfigPublisherInterface
 {
     /**
      * @var PublisherInterface
@@ -32,7 +34,7 @@ class AsyncConfigPublisher implements \Magento\AsyncConfig\Api\AsyncConfigPublis
     private $serializer;
 
     /**
-     * @var \Magento\Framework\Filesystem\DirectoryList
+     * @var FilesystemDirectoryList
      */
     private $dir;
 
@@ -46,14 +48,14 @@ class AsyncConfigPublisher implements \Magento\AsyncConfig\Api\AsyncConfigPublis
      * @param AsyncConfigMessageInterfaceFactory $asyncConfigFactory
      * @param PublisherInterface $publisher
      * @param Json $json
-     * @param \Magento\Framework\Filesystem\DirectoryList $dir
+     * @param FilesystemDirectoryList $dir
      * @param File $file
      */
     public function __construct(
         AsyncConfigMessageInterfaceFactory $asyncConfigFactory,
         PublisherInterface $publisher,
         Json $json,
-        \Magento\Framework\Filesystem\DirectoryList $dir,
+        FilesystemDirectoryList $dir,
         File $file
     ) {
         $this->asyncConfigFactory = $asyncConfigFactory;
@@ -100,7 +102,10 @@ class AsyncConfigPublisher implements \Magento\AsyncConfig\Api\AsyncConfigPublis
     private function changeImagePath(array &$fields)
     {
         foreach ($fields as &$data) {
-            if (!empty($data['value']['tmp_name'])) {
+            if (!isset($data['value']) || !is_array($data['value'])) {
+                continue;
+            }
+            if (!empty($data['value']['tmp_name']) && is_uploaded_file($data['value']['tmp_name'])) {
                 $newPath =
                     $this->dir->getPath(DirectoryList::MEDIA) . '/' .
                     // phpcs:ignore Magento2.Functions.DiscouragedFunction
@@ -110,6 +115,8 @@ class AsyncConfigPublisher implements \Magento\AsyncConfig\Api\AsyncConfigPublis
                     $newPath
                 );
                 $data['value']['tmp_name'] = $newPath;
+            } elseif (array_key_exists('tmp_name', $data['value'])) {
+                unset($data['value']['tmp_name']);
             }
         }
     }

--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -148,6 +148,7 @@ class Gallery extends AbstractView
                     'isMain' => $this->isMainImage($image),
                     'type' => $mediaType !== null ? str_replace('external-', '', $mediaType) : '',
                     'videoUrl' => $image->getVideoUrl(),
+                    '__disableTmpl' => true,
                 ]
             );
             foreach ($this->getGalleryImagesConfig()->getItems() as $imageConfig) {
@@ -168,6 +169,7 @@ class Gallery extends AbstractView
                 'isMain' => true,
                 'type' => 'image',
                 'videoUrl' => null,
+                '__disableTmpl' => true,
             ];
         }
         return json_encode($imagesItems);

--- a/app/code/Magento/Catalog/Block/Ui/ProductViewCounter.php
+++ b/app/code/Magento/Catalog/Block/Ui/ProductViewCounter.php
@@ -116,6 +116,26 @@ class ProductViewCounter extends Template
     }
 
     /**
+     * Recursively adds __disableTmpl to every array level
+     *
+     * @param array $data
+     * @return array
+     */
+    private function disableTemplating(array $data): array
+    {
+        $isAssociative = (bool) count(array_filter(array_keys($data), 'is_string'));
+        if ($isAssociative) {
+            $data['__disableTmpl'] = true;
+        }
+        foreach ($data as &$value) {
+            if (is_array($value)) {
+                $value = $this->disableTemplating($value);
+            }
+        }
+        return $data;
+    }
+
+    /**
      * Calculate item data, that will need to application on frontend
      *
      * Product data calculated on this page, will be cached, for all next web api
@@ -154,6 +174,7 @@ class ProductViewCounter extends Template
             ->collect($product, $productRender);
         $data = $this->hydrator->extract($productRender);
         $data['is_available'] = $product->isAvailable();
+        $data = $this->disableTemplating($data);
 
         $currentProductData = [
             'items' => [

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Item.php
@@ -129,12 +129,15 @@ class Item extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $data = parent::_prepareDataForTable($object, $table);
         $ifNullSql = $this->getConnection()->getIfNullSql('qty');
         if (!$object->isObjectNew() && $object->getQtyCorrection()) {
+            $rawQty  = (float) $object->getQtyCorrection();
+            $safeQty = is_finite($rawQty) ? $rawQty : 0.0;
+
             if ($object->getQty() === null) {
                 $data['qty'] = null;
-            } elseif ($object->getQtyCorrection() < 0) {
-                $data['qty'] = new \Zend_Db_Expr($ifNullSql . '-' . abs((float) $object->getQtyCorrection()));
+            } elseif ($safeQty < 0) {
+                $data['qty'] = new \Zend_Db_Expr($ifNullSql . '-' . abs($safeQty));
             } else {
-                $data['qty'] = new \Zend_Db_Expr($ifNullSql . '+' . $object->getQtyCorrection());
+                $data['qty'] = new \Zend_Db_Expr($ifNullSql . '+' . $safeQty);
             }
         }
         return $data;

--- a/app/code/Magento/CatalogInventory/Observer/SaveInventoryDataObserver.php
+++ b/app/code/Magento/CatalogInventory/Observer/SaveInventoryDataObserver.php
@@ -152,6 +152,7 @@ class SaveInventoryDataObserver implements ObserverInterface
     private function getStockData(Product $product)
     {
         $stockData = $product->getStockData();
+        unset($stockData['qty_correction']);
         $stockData['product_id'] = $product->getId();
 
         if (!isset($stockData['website_id'])) {

--- a/app/code/Magento/CatalogUrlRewriteGraphQl/Plugin/Model/Resolver/EntityUrlExcludeDisabledProductPlugin.php
+++ b/app/code/Magento/CatalogUrlRewriteGraphQl/Plugin/Model/Resolver/EntityUrlExcludeDisabledProductPlugin.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogUrlRewriteGraphQl\Plugin\Model\Resolver;
+
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\UrlRewriteGraphQl\Model\Resolver\EntityUrl;
+
+/**
+ * Validation for product status for url resolver
+ */
+class EntityUrlExcludeDisabledProductPlugin
+{
+    /**
+     * Constant for product type
+     */
+    private const TYPE_PRODUCT = 'product';
+
+    /**
+     * @var array
+     */
+    private array $statusCache = [];
+
+    /**
+     * @var ProductResource
+     */
+    private ProductResource $productResource;
+
+    /**
+     * @param ProductResource $productResource
+     */
+    public function __construct(
+        ProductResource $productResource
+    ) {
+        $this->productResource = $productResource;
+    }
+
+    /**
+     * After plugin for EntityUrl resolver to exclude disabled products
+     *
+     * @param EntityUrl $subject
+     * @param array|null $result
+     * @param Field $field
+     * @param mixed $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @return array|null
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function afterResolve(
+        EntityUrl $subject,
+        ?array $result,
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        ?array $value = null,
+        ?array $args = null
+    ): ?array {
+        if ($result === null || strtolower($result['type'] ?? '') !== self::TYPE_PRODUCT || empty($result['id'])) {
+            return $result;
+        }
+        $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
+        $cacheKey = $result['id'] . '_' . $storeId;
+        if (!array_key_exists($cacheKey, $this->statusCache)) {
+            $this->statusCache[$cacheKey] = $this->productResource->getAttributeRawValue(
+                (int)$result['id'],
+                'status',
+                $storeId
+            );
+        }
+        $status = $this->statusCache[$cacheKey];
+        if ($status === false || (int)$status !== Status::STATUS_ENABLED) {
+            return null;
+        }
+        return $result;
+    }
+}

--- a/app/code/Magento/CatalogUrlRewriteGraphQl/etc/di.xml
+++ b/app/code/Magento/CatalogUrlRewriteGraphQl/etc/di.xml
@@ -39,4 +39,8 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\UrlRewriteGraphQl\Model\Resolver\EntityUrl">
+        <plugin name="validateProductStatusUrlResolverPlugin"
+                type="Magento\CatalogUrlRewriteGraphQl\Plugin\Model\Resolver\EntityUrlExcludeDisabledProductPlugin"/>
+    </type>
 </config>

--- a/app/code/Magento/Checkout/Model/GuestPaymentInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/GuestPaymentInformationManagement.php
@@ -17,6 +17,7 @@ use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteAddressValidationService;
 use Psr\Log\LoggerInterface as Logger;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
 
 /**
  * Guest payment information management model.
@@ -88,6 +89,11 @@ class GuestPaymentInformationManagement implements \Magento\Checkout\Api\GuestPa
     private $quoteAddressValidationService;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * @param \Magento\Quote\Api\GuestBillingAddressManagementInterface $billingAddressManagement
      * @param \Magento\Quote\Api\GuestPaymentMethodManagementInterface $paymentMethodManagement
      * @param \Magento\Quote\Api\GuestCartManagementInterface $cartManagement
@@ -99,6 +105,7 @@ class GuestPaymentInformationManagement implements \Magento\Checkout\Api\GuestPa
      * @param PaymentSavingRateLimiterInterface|null $savingRateLimiter
      * @param AddressComparatorInterface|null $addressComparator
      * @param QuoteAddressValidationService|null $quoteAddressValidationService
+     * @param GetGuestCart|null $getGuestCart
      * @codeCoverageIgnore
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -113,7 +120,8 @@ class GuestPaymentInformationManagement implements \Magento\Checkout\Api\GuestPa
         ?PaymentProcessingRateLimiterInterface $paymentsRateLimiter = null,
         ?PaymentSavingRateLimiterInterface $savingRateLimiter = null,
         ?AddressComparatorInterface $addressComparator = null,
-        ?QuoteAddressValidationService $quoteAddressValidationService = null
+        ?QuoteAddressValidationService $quoteAddressValidationService = null,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->billingAddressManagement = $billingAddressManagement;
         $this->paymentMethodManagement = $paymentMethodManagement;
@@ -130,6 +138,7 @@ class GuestPaymentInformationManagement implements \Magento\Checkout\Api\GuestPa
         $this->quoteAddressValidationService = $quoteAddressValidationService
             ?? ObjectManager::getInstance()->get(QuoteAddressValidationService::class);
         $this->logger = $logger;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
@@ -196,6 +205,7 @@ class GuestPaymentInformationManagement implements \Magento\Checkout\Api\GuestPa
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
         /** @var Quote $quote */
         $quote = $this->cartRepository->getActive($quoteIdMask->getQuoteId());
+        $this->getGuestCart->checkIsGuestCart((int)$quote->getCustomerId(), $cartId);
 
         $this->quoteAddressValidationService->validateAddressesWithRules($quote, null, $billingAddress);
 
@@ -227,6 +237,7 @@ class GuestPaymentInformationManagement implements \Magento\Checkout\Api\GuestPa
     public function getPaymentInformation($cartId)
     {
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->paymentInformationManagement->getPaymentInformation($quoteIdMask->getQuoteId());
     }
 

--- a/app/code/Magento/Checkout/Model/GuestShippingInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/GuestShippingInformationManagement.php
@@ -6,6 +6,8 @@
 namespace Magento\Checkout\Model;
 
 use Magento\Checkout\Api\Data\ShippingInformationInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
 
 class GuestShippingInformationManagement implements \Magento\Checkout\Api\GuestShippingInformationManagementInterface
 {
@@ -20,16 +22,24 @@ class GuestShippingInformationManagement implements \Magento\Checkout\Api\GuestS
     protected $shippingInformationManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * @param \Magento\Quote\Model\QuoteIdMaskFactory $quoteIdMaskFactory
      * @param \Magento\Checkout\Api\ShippingInformationManagementInterface $shippingInformationManagement
+     * @param GetGuestCart|null $getGuestCart
      * @codeCoverageIgnore
      */
     public function __construct(
         \Magento\Quote\Model\QuoteIdMaskFactory $quoteIdMaskFactory,
-        \Magento\Checkout\Api\ShippingInformationManagementInterface $shippingInformationManagement
+        \Magento\Checkout\Api\ShippingInformationManagementInterface $shippingInformationManagement,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->shippingInformationManagement = $shippingInformationManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
@@ -41,6 +51,7 @@ class GuestShippingInformationManagement implements \Magento\Checkout\Api\GuestS
     ) {
         /** @var $quoteIdMask \Magento\Quote\Model\QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingInformationManagement->saveAddressInformation(
             (int) $quoteIdMask->getQuoteId(),
             $addressInformation

--- a/app/code/Magento/Checkout/Model/GuestTotalsInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/GuestTotalsInformationManagement.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Checkout\Model;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+
 class GuestTotalsInformationManagement implements \Magento\Checkout\Api\GuestTotalsInformationManagementInterface
 {
     /**
@@ -18,20 +21,28 @@ class GuestTotalsInformationManagement implements \Magento\Checkout\Api\GuestTot
     protected $totalsInformationManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * @param \Magento\Quote\Model\QuoteIdMaskFactory $quoteIdMaskFactory
      * @param \Magento\Checkout\Api\TotalsInformationManagementInterface $totalsInformationManagement
+     * @param GetGuestCart|null $getGuestCart
      * @codeCoverageIgnore
      */
     public function __construct(
         \Magento\Quote\Model\QuoteIdMaskFactory $quoteIdMaskFactory,
-        \Magento\Checkout\Api\TotalsInformationManagementInterface $totalsInformationManagement
+        \Magento\Checkout\Api\TotalsInformationManagementInterface $totalsInformationManagement,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->totalsInformationManagement = $totalsInformationManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function calculate(
         $cartId,
@@ -39,6 +50,7 @@ class GuestTotalsInformationManagement implements \Magento\Checkout\Api\GuestTot
     ) {
         /** @var $quoteIdMask \Magento\Quote\Model\QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->totalsInformationManagement->calculate(
             $quoteIdMask->getQuoteId(),
             $addressInformation

--- a/app/code/Magento/Customer/etc/config.xml
+++ b/app/code/Magento/Customer/etc/config.xml
@@ -105,12 +105,5 @@
                 <section_data_lifetime>60</section_data_lifetime>
             </online_customers>
         </customer>
-        <system>
-            <media_storage_configuration>
-                <allowed_resources>
-                    <customer_address_folder>customer_address</customer_address_folder>
-                </allowed_resources>
-            </media_storage_configuration>
-        </system>
     </default>
 </config>

--- a/app/code/Magento/GiftMessage/Model/GuestCartRepository.php
+++ b/app/code/Magento/GiftMessage/Model/GuestCartRepository.php
@@ -10,6 +10,8 @@ use Magento\GiftMessage\Api\Data\MessageInterface;
 use Magento\GiftMessage\Api\GuestCartRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
 
 /**
  * Shopping cart gift message repository object for guest
@@ -27,34 +29,45 @@ class GuestCartRepository implements GuestCartRepositoryInterface
     protected $quoteIdMaskFactory;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * @param CartRepository $repository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         CartRepository $repository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->repository = $repository;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
-        return $this->repository->get($quoteIdMask->getQuoteId());
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
+        $quote = $this->repository->get($quoteIdMask->getQuoteId());
+        return $quote;
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function save($cartId, MessageInterface $giftMessage)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->repository->save($quoteIdMask->getQuoteId(), $giftMessage);
     }
 }

--- a/app/code/Magento/GiftMessage/Model/GuestItemRepository.php
+++ b/app/code/Magento/GiftMessage/Model/GuestItemRepository.php
@@ -10,6 +10,8 @@ use Magento\GiftMessage\Api\Data\MessageInterface;
 use Magento\GiftMessage\Api\GuestItemRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
 
 /**
  * Shopping cart gift message item repository object for guest
@@ -27,34 +29,45 @@ class GuestItemRepository implements GuestItemRepositoryInterface
     protected $quoteIdMaskFactory;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * @param ItemRepository $repository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         ItemRepository $repository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->repository = $repository;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId, $itemId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
-        return $this->repository->get($quoteIdMask->getQuoteId(), $itemId);
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
+        $quoteItem = $this->repository->get($quoteIdMask->getQuoteId(), $itemId);
+        return $quoteItem;
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function save($cartId, MessageInterface $giftMessage, $itemId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->repository->save($quoteIdMask->getQuoteId(), $giftMessage, $itemId);
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GetGuestCart.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GetGuestCart.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Model\GuestCart;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+
+/**
+ * Get cart for guest users.
+ */
+class GetGuestCart
+{
+    /**
+     * Initialize dependencies
+     *
+     * @param CartRepositoryInterface $cartRepository
+     */
+    public function __construct(
+        private readonly CartRepositoryInterface $cartRepository
+    ) {
+    }
+
+    /**
+     * Get quote by masked cart ID only if it is a guest cart.
+     *
+     * @param string $maskedCartId
+     * @param int $quoteId
+     * @return Quote
+     * @throws NoSuchEntityException
+     */
+    public function execute(string $maskedCartId, int $quoteId): Quote
+    {
+        /** @var Quote $quote */
+        $quote = $this->cartRepository->get($quoteId);
+        $this->checkIsGuestCart((int) $quote->getCustomerId(), $maskedCartId);
+
+        return $quote;
+    }
+
+    /**
+     * Check if the cart is a guest cart.
+     *
+     * @param int $customerId
+     * @param string $maskedCartId
+     * @throws NoSuchEntityException
+     */
+    public function checkIsGuestCart(int $customerId, string $maskedCartId): void
+    {
+        if ($customerId !== 0) {
+            throw new NoSuchEntityException(
+                __("Could not find a cart with ID '%masked_cart_id'", ['masked_cart_id' => $maskedCartId])
+            );
+        }
+    }
+}

--- a/app/code/Magento/Quote/Model/GuestCart/GuestBillingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestBillingAddressManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\GuestBillingAddressManagementInterface;
 use Magento\Quote\Api\BillingAddressManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Billing address management service for guest carts.
@@ -26,36 +28,46 @@ class GuestBillingAddressManagement implements GuestBillingAddressManagementInte
     private $billingAddressManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a quote billing address service object.
      *
      * @param BillingAddressManagementInterface $billingAddressManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         BillingAddressManagementInterface $billingAddressManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->billingAddressManagement = $billingAddressManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function assign($cartId, \Magento\Quote\Api\Data\AddressInterface $address, $useForShipping = false)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return (int)$this->billingAddressManagement->assign($quoteIdMask->getQuoteId(), $address, $useForShipping);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->billingAddressManagement->get($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartItemRepository.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartItemRepository.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\Data\CartItemInterface;
 use Magento\Quote\Api\CartItemRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart Item repository class for guest carts.
@@ -16,7 +18,7 @@ use Magento\Quote\Model\QuoteIdMaskFactory;
 class GuestCartItemRepository implements \Magento\Quote\Api\GuestCartItemRepositoryInterface
 {
     /**
-     * @var \Magento\Quote\Api\CartItemRepositoryInterface
+     * @var CartItemRepositoryInterface
      */
     protected $repository;
 
@@ -26,26 +28,35 @@ class GuestCartItemRepository implements \Magento\Quote\Api\GuestCartItemReposit
     protected $quoteIdMaskFactory;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a read service object.
      *
-     * @param \Magento\Quote\Api\CartItemRepositoryInterface $repository
+     * @param CartItemRepositoryInterface $repository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
-        \Magento\Quote\Api\CartItemRepositoryInterface $repository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        CartItemRepositoryInterface $repository,
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->repository = $repository;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getList($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         $cartItemList = $this->repository->getList($quoteIdMask->getQuoteId());
         /** @var $item CartItemInterface */
         foreach ($cartItemList as $item) {
@@ -55,23 +66,25 @@ class GuestCartItemRepository implements \Magento\Quote\Api\GuestCartItemReposit
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
-    public function save(\Magento\Quote\Api\Data\CartItemInterface $cartItem)
+    public function save(CartItemInterface $cartItem)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartItem->getQuoteId(), 'masked_id');
+        $this->getGuestCart->execute($cartItem->getQuoteId(), (int) $quoteIdMask->getQuoteId());
         $cartItem->setQuoteId($quoteIdMask->getQuoteId());
         return $this->repository->save($cartItem);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function deleteById($cartId, $itemId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->repository->deleteById($quoteIdMask->getQuoteId(), $itemId);
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartManagement.php
@@ -12,6 +12,8 @@ use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart Management class for guest carts.
@@ -36,25 +38,33 @@ class GuestCartManagement implements GuestCartManagementInterface
     protected $cartRepository;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Initialize dependencies.
      *
      * @param CartManagementInterface $quoteManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
      * @param CartRepositoryInterface $cartRepository
+     * @param GetGuestCart|null $getGuestCart
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         CartManagementInterface $quoteManagement,
         QuoteIdMaskFactory $quoteIdMaskFactory,
-        CartRepositoryInterface $cartRepository
+        CartRepositoryInterface $cartRepository,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteManagement = $quoteManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->cartRepository = $cartRepository;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function createEmptyCart()
     {
@@ -66,22 +76,24 @@ class GuestCartManagement implements GuestCartManagementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function assignCustomer($cartId, $customerId, $storeId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->quoteManagement->assignCustomer($quoteIdMask->getQuoteId(), $customerId, $storeId);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function placeOrder($cartId, ?PaymentInterface $paymentMethod = null)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         $this->cartRepository->get($quoteIdMask->getQuoteId())
             ->setCheckoutMethod(CartManagementInterface::METHOD_GUEST);
         return $this->quoteManagement->placeOrder($quoteIdMask->getQuoteId(), $paymentMethod);

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartRepository.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartRepository.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\GuestCartRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart Repository class for guest carts.
@@ -26,26 +28,36 @@ class GuestCartRepository implements GuestCartRepositoryInterface
     protected $quoteRepository;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Initialize dependencies.
      *
      * @param CartRepositoryInterface $quoteRepository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         CartRepositoryInterface $quoteRepository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->quoteRepository = $quoteRepository;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
-        return $this->quoteRepository->get($quoteIdMask->getQuoteId());
+        $quote = $this->quoteRepository->get($quoteIdMask->getQuoteId());
+        $this->getGuestCart->checkIsGuestCart((int)$quote->getCustomerId(), $cartId);
+        return $quote;
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalManagement.php
@@ -7,6 +7,9 @@ namespace Magento\Quote\Model\GuestCart;
 
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Api\GuestCartTotalManagementInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Quote\Api\CartTotalManagementInterface;
 
 /**
  * @inheritDoc
@@ -14,7 +17,7 @@ use Magento\Quote\Api\GuestCartTotalManagementInterface;
 class GuestCartTotalManagement implements GuestCartTotalManagementInterface
 {
     /**
-     * @var \Magento\Quote\Api\CartTotalManagementInterface
+     * @var CartTotalManagementInterface
      */
     protected $cartTotalManagement;
 
@@ -24,19 +27,27 @@ class GuestCartTotalManagement implements GuestCartTotalManagementInterface
     protected $quoteIdMaskFactory;
 
     /**
-     * @param \Magento\Quote\Api\CartTotalManagementInterface $cartTotalManagement
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
+     * @param CartTotalManagementInterface $cartTotalManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
-        \Magento\Quote\Api\CartTotalManagementInterface $cartTotalManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        CartTotalManagementInterface $cartTotalManagement,
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->cartTotalManagement = $cartTotalManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function collectTotals(
         $cartId,
@@ -46,6 +57,7 @@ class GuestCartTotalManagement implements GuestCartTotalManagementInterface
         ?\Magento\Quote\Api\Data\TotalsAdditionalDataInterface $additionalData = null
     ) {
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->cartTotalManagement->collectTotals(
             $quoteIdMask->getQuoteId(),
             $paymentMethod,

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalRepository.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalRepository.php
@@ -10,6 +10,8 @@ use Magento\Quote\Api\CartTotalRepositoryInterface;
 use Magento\Quote\Api\GuestCartTotalRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart totals repository class for guest carts.
@@ -27,26 +29,35 @@ class GuestCartTotalRepository implements GuestCartTotalRepositoryInterface
     private $cartTotalRepository;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a cart totals data object.
      *
      * @param CartTotalRepositoryInterface $cartTotalRepository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         CartTotalRepositoryInterface $cartTotalRepository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->cartTotalRepository = $cartTotalRepository;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->cartTotalRepository->get($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCouponManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCouponManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\GuestCouponManagementInterface;
 use Magento\Quote\Api\CouponManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Coupon management class for guest carts.
@@ -26,17 +28,25 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     private $couponManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a coupon read service object.
      *
      * @param CouponManagementInterface $couponManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         CouponManagementInterface $couponManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->couponManagement = $couponManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
@@ -46,6 +56,7 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->couponManagement->get($quoteIdMask->getQuoteId());
     }
 
@@ -56,6 +67,7 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->couponManagement->set($quoteIdMask->getQuoteId(), trim($couponCode));
     }
 
@@ -66,6 +78,7 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->couponManagement->remove($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestPaymentMethodManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestPaymentMethodManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\PaymentMethodManagementInterface;
 use Magento\Quote\Api\GuestPaymentMethodManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Payment method management class for guest carts.
@@ -26,46 +28,57 @@ class GuestPaymentMethodManagement implements GuestPaymentMethodManagementInterf
     protected $paymentMethodManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Initialize dependencies.
      *
      * @param PaymentMethodManagementInterface $paymentMethodManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         PaymentMethodManagementInterface $paymentMethodManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->paymentMethodManagement = $paymentMethodManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function set($cartId, \Magento\Quote\Api\Data\PaymentInterface $method)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->paymentMethodManagement->set($quoteIdMask->getQuoteId(), $method);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->paymentMethodManagement->get($quoteIdMask->getQuoteId());
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getList($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->paymentMethodManagement->getList($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestShippingAddressManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Model\GuestCart\GuestShippingAddressManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Model\ShippingAddressManagementInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
 
 /**
  * Shipping address management class for guest carts.
@@ -26,36 +28,46 @@ class GuestShippingAddressManagement implements GuestShippingAddressManagementIn
     protected $shippingAddressManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a quote shipping address write service object.
      *
      * @param ShippingAddressManagementInterface $shippingAddressManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         ShippingAddressManagementInterface $shippingAddressManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->shippingAddressManagement = $shippingAddressManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function assign($cartId, \Magento\Quote\Api\Data\AddressInterface $address)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingAddressManagement->assign($quoteIdMask->getQuoteId(), $address);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingAddressManagement->get($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestShippingMethodManagement.php
@@ -13,6 +13,7 @@ use Magento\Quote\Api\ShipmentEstimationInterface;
 use Magento\Quote\Api\ShippingMethodManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
 
 /**
  * Shipping method management class for guest carts.
@@ -38,56 +39,68 @@ class GuestShippingMethodManagement implements
     private $shipmentEstimationManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a shipping method read service object.
      *
      * @param ShippingMethodManagementInterface $shippingMethodManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         ShippingMethodManagementInterface $shippingMethodManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->shippingMethodManagement = $shippingMethodManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->get($quoteIdMask->getQuoteId());
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getList($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->getList($quoteIdMask->getQuoteId());
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function set($cartId, $carrierCode, $methodCode)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->set($quoteIdMask->getQuoteId(), $carrierCode, $methodCode);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function estimateByAddress($cartId, \Magento\Quote\Api\Data\EstimateAddressInterface $address)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->estimateByAddress($quoteIdMask->getQuoteId(), $address);
     }
 
@@ -98,6 +111,7 @@ class GuestShippingMethodManagement implements
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
 
         return $this->getShipmentEstimationManagement()
             ->estimateByExtendedAddress((int) $quoteIdMask->getQuoteId(), $address);
@@ -105,8 +119,10 @@ class GuestShippingMethodManagement implements
 
     /**
      * Get shipment estimation management service
+     *
      * @return ShipmentEstimationInterface
      * @deprecated 100.0.7
+     * @see getShipmentEstimationManagement
      */
     private function getShipmentEstimationManagement()
     {

--- a/app/code/Magento/Quote/etc/di.xml
+++ b/app/code/Magento/Quote/etc/di.xml
@@ -194,4 +194,7 @@
     <preference for="Magento\Quote\Model\Quote\Item\CartItemValidatorResultInterface" type="Magento\Quote\Model\Quote\Item\CartItemValidatorResult"/>
     <virtualType name="Magento\Quote\Model\Quote\Item\CartItemValidatorChainOnSave" type="Magento\Quote\Model\Quote\Item\CartItemValidatorChain"/>
     <preference for="Magento\Quote\Model\Address\Validator\AddressAttributeValidatorInterface" type="Magento\Quote\Model\Address\Validator\AddressAttributeValidator"/>
+    <type name="Magento\Quote\Model\Quote">
+        <plugin name="validateQuoteAddress" type="Magento\Quote\Plugin\QuoteAddress" />
+    </type>
 </config>

--- a/app/code/Magento/Quote/etc/webapi_rest/di.xml
+++ b/app/code/Magento/Quote/etc/webapi_rest/di.xml
@@ -18,7 +18,6 @@
     </type>
     <type name="Magento\Quote\Model\Quote">
         <plugin name="updateQuoteStoreId" type="Magento\Quote\Model\Quote\Plugin\UpdateQuoteStoreId" />
-        <plugin name="validateQuoteAddress" type="Magento\Quote\Plugin\QuoteAddress" />
     </type>
     <type name="Magento\Quote\Model\QuoteValidator">
         <plugin name="error_redirect_processor" type="Magento\Quote\Plugin\Webapi\Model\ErrorRedirectProcessor" />

--- a/app/code/Magento/Quote/i18n/en_US.csv
+++ b/app/code/Magento/Quote/i18n/en_US.csv
@@ -76,3 +76,4 @@ Carts,Carts
 "Identity type not found","Identity type not found"
 "Invalid order backpressure limit config","Invalid order backpressure limit config"
 "Please check input parameters.","Please check input parameters."
+"Could not find a cart with ID '%masked_cart_id'","Could not find a cart with ID '%masked_cart_id'"

--- a/app/code/Magento/Store/etc/config.xml
+++ b/app/code/Magento/Store/etc/config.xml
@@ -141,6 +141,13 @@
                     <svgz>svgz</svgz>
                     <xml>xml</xml>
                     <xhtml>xhtml</xhtml>
+                    <hta>hta</hta>
+                    <mhtml>mhtml</mhtml>
+                    <mht>mht</mht>
+                    <htc>htc</htc>
+                    <xht>xht</xht>
+                    <shtm>shtm</shtm>
+                    <php8>php8</php8>
                 </protected_extensions>
                 <public_files_valid_paths>
                     <protected>

--- a/app/code/Magento/Translation/Model/Inline/Parser.php
+++ b/app/code/Magento/Translation/Model/Inline/Parser.php
@@ -7,8 +7,11 @@ declare(strict_types=1);
 
 namespace Magento\Translation\Model\Inline;
 
+use DOMDocument;
+use Normalizer;
 use Laminas\Filter\FilterInterface;
 use Magento\Backend\App\Area\FrontNameResolver;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Translate\Inline\ParserInterface;
 use Magento\Translation\Model\ResourceModel\StringFactory;
 use Magento\Translation\Model\ResourceModel\StringUtils;
@@ -116,6 +119,9 @@ class Parser implements ParserInterface
      * @var array
      */
     private $filterTagsExpression = [
+        '/&lt;\/?(script|meta|link|frame|iframe|object|embed|form|input|style)[^&]*&gt;/i',
+        '/&lt;[^&]*(ondblclick|onclick|onkeydown|onkeypress|onkeyup|onmousedown|onmousemove|' .
+            'onmouseout|onmouseover|onmouseup|onload|onunload|onerror)[^&]*&gt;/i',
         '/\b(alert|eval|setTimeout|setInterval|Function|setImmediate|requestAnimationFrame|document\.(write' .
             '|writeln)|innerHTML|outerHTML|insertAdjacentHTML|console\.(log|error|warn|info|debug))\s*[=(]/i',
         '/\b(window|this|self)\s*\[\s*[\'"]?(alert|eval)[\'"]?\s*\]/i',
@@ -169,6 +175,11 @@ class Parser implements ParserInterface
     private $relatedCacheTypes;
 
     /**
+     * @var Normalizer
+     */
+    private $normalizer;
+
+    /**
      * Initialize base inline translation model
      *
      * @param StringUtilsFactory $resource
@@ -180,6 +191,7 @@ class Parser implements ParserInterface
      * @param Escaper $escaper
      * @param CacheManager $cacheManager
      * @param array $relatedCacheTypes
+     * @param Normalizer|null $normalizer
      */
     public function __construct(
         StringUtilsFactory $resource,
@@ -190,7 +202,8 @@ class Parser implements ParserInterface
         InlineInterface $translateInline,
         Escaper $escaper,
         CacheManager $cacheManager,
-        array $relatedCacheTypes = []
+        array $relatedCacheTypes = [],
+        ?Normalizer $normalizer = null
     ) {
         $this->_resourceFactory = $resource;
         $this->_storeManager = $storeManager;
@@ -201,6 +214,8 @@ class Parser implements ParserInterface
         $this->escaper = $escaper;
         $this->cacheManager = $cacheManager;
         $this->relatedCacheTypes = $relatedCacheTypes;
+        $this->normalizer = $normalizer
+            ?? ObjectManager::getInstance()->get(Normalizer::class);
     }
 
     /**
@@ -222,6 +237,7 @@ class Parser implements ParserInterface
 
         $this->_validateTranslationParams($translateParams);
         $this->_filterTranslationParams($translateParams, ['custom']);
+        $this->filterExternalLinks($translateParams);
 
         /** @var $validStoreId int */
         $validStoreId = $this->_storeManager->getStore()->getId();
@@ -286,11 +302,100 @@ class Parser implements ParserInterface
     }
 
     /**
+     * Sanitize external links in translations
+     *
+     * @param array $translateParams
+     * @return void
+     */
+    private function filterExternalLinks(array &$translateParams): void
+    {
+        foreach ($translateParams as &$param) {
+            if (isset($param['custom']) && is_string($param['custom'])) {
+                $param['custom'] = $this->removeExternalLinks($param['custom']);
+            }
+        }
+    }
+
+    /**
+     * Remove external links from HTML content, converting them to plain text
+     *
+     * @param string $content
+     * @return string
+     */
+    private function removeExternalLinks(string $content): string
+    {
+        $content = trim($content);
+        if ($content === '') {
+            return $content;
+        }
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        libxml_use_internal_errors(true);
+        $wrapper = '<div>' . $content . '</div>';
+        $dom->loadHTML(
+            '<?xml encoding="UTF-8"?>' . $wrapper,
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        );
+        libxml_clear_errors();
+        $xpath = new \DOMXPath($dom);
+        foreach ($xpath->query('//a[@href]') as $anchor) {
+            $href = trim(html_entity_decode($anchor->getAttribute('href'), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+            if ($this->isExternal($href)) {
+                $anchor->parentNode->replaceChild($dom->createTextNode($anchor->textContent), $anchor);
+            }
+        }
+        $wrapper = $dom->getElementsByTagName('div')->item(0);
+        $result = '';
+        foreach ($wrapper->childNodes as $child) {
+            $result .= $dom->saveHTML($child);
+        }
+        return $result;
+    }
+
+    /**
+     * Method to verify if the href is external
+     *
+     * @param string $href
+     * @return bool
+     */
+    private function isExternal(string $href): bool
+    {
+        $href = preg_replace('/[\x00-\x1F\x7F]+/u', '', $href);
+        $href = trim($href);
+
+        if ($href === '' || $href[0] === '#') {
+            return false;
+        }
+
+        if (class_exists(Normalizer::class) && $this->normalizer !== null) {
+            $normalized = $this->normalizer->normalize($href, Normalizer::FORM_KC);
+            if ($normalized !== false) {
+                $href = $normalized;
+            }
+        }
+
+        if (strncmp($href, '//', 2) === 0 || strncasecmp($href, 'www.', 4) === 0) {
+            return true;
+        }
+
+        if (preg_match('/^[a-z0-9.-]+\.[a-z]{2,}/i', $href)) {
+            return true;
+        }
+
+        $colonPos = strpos($href, ':');
+        if ($colonPos === false) {
+            return false;
+        }
+
+        $scheme = preg_replace('/\s+/', '', substr($href, 0, $colonPos));
+        return $scheme !== '' && preg_match('/^[a-z][a-z0-9+\-.]*$/i', $scheme);
+    }
+
+    /**
      * Add additional filters to translation strings
      *
      * @return void
      */
-    private function addTranslationFilterExpression()
+    private function addTranslationFilterExpression(): void
     {
         if ($this->filterExpressionsAdded) {
             return;

--- a/lib/internal/Magento/Framework/View/Element/UiComponent/DataProvider/Sanitizer.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/DataProvider/Sanitizer.php
@@ -50,7 +50,7 @@ class Sanitizer
             } elseif (!is_bool($config)
                 && !array_key_exists($key, $config)
                 && (is_string($datum) || $datum instanceof Phrase)
-                && preg_match('/\$\{.+\}/', (string)$datum)
+                && preg_match('/\$\{.+\}/s', (string)$datum)
             ) {
                 //Templating is not disabled for all properties or for this property specifically
                 //Property is a string that contains template syntax, so we are disabling its rendering

--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -189,6 +189,10 @@ location /media/customer/ {
     deny all;
 }
 
+location /media/customer_address/ {
+    deny all;
+}
+
 location /media/downloadable/ {
     deny all;
 }


### PR DESCRIPTION
## Summary

Ports Adobe's isolated security patch `249-2026-07-001-CE` to the Mage-OS source-tree layout. The upstream patch is authored against an installed-instance layout (`vendor/magento/module-*`), so paths are rewritten to source layout (`app/code/Magento/*`, `lib/internal/Magento/Framework/*`).

This content is not obtainable from any Magento git tag or Composer package — `github.com/magento/magento2` and `repo.magento.com` both stop at `2.4.9`, with no post-release tag or patched package version. The isolated patch file is the only source.

Applies cleanly against `main` (no hunk conflicts). All changed/new PHP files lint clean; all touched XML is well-formed.

## Fixes included

**Guest cart takeover (16 files).** New `Quote\Model\GuestCart\GetGuestCart` resolves a masked cart ID and verifies the quote is genuinely a guest cart (`checkIsGuestCart()`) before any guest-facing endpoint acts on it — cart, items, coupons, billing/shipping address, payment/shipping methods, totals, gift message. Previously a masked cart ID could be used against the guest endpoints to reach a logged-in customer's cart.

Related: the `validateQuoteAddress` plugin moves from `etc/webapi_rest/di.xml` to `etc/di.xml`, promoting address validation from REST-only to all entry points.

**Stored XSS via inline translation.** `Translation\Model\Inline\Parser` now strips `script`/`meta`/`link`/`frame`/`iframe`/`object`/`embed`/`form`/`input`/`style` tags and `on*` event handlers, and filters external links out of translated content.

**Template-injection sanitizer bypass.** `Framework\View\Element\UiComponent\DataProvider\Sanitizer`: `/\$\{.+\}/` gains the `s` flag, so a `${...}` payload containing a newline no longer evades the sanitizer.

**Template injection via product data.** `__disableTmpl => true` on `Catalog\Block\Product\View\Gallery` and `Catalog\Block\Ui\ProductViewCounter`.

**Disabled product disclosure via GraphQL.** New `EntityUrlExcludeDisabledProductPlugin` on the CatalogUrlRewrite GraphQL URL resolver.

**Customer address media hardening.** `customer_address` removed from allowed media resources; `hta`/`mhtml`/`mht`/`htc`/`xht`/`shtm`/`php8` added to the blocked-extension list; `deny all` on `/media/customer_address/` in `nginx.conf.sample`.

## Deliberately excluded: `vendor/bin/patch-status`

The upstream patch also creates `vendor/bin/patch-status`, a minified, auto-generated single-file PHP tool ("Adobe Commerce Monthly Security Release Versioning Tool"). It is **not** included here:

- `vendor/bin/` is Composer-generated — the file has no source-tree equivalent, so there is nowhere in this repo to put it.
- It reads `auth.json` / `COMPOSER_AUTH` credentials and fetches `https://repo.magento.com/patch/patch-registry.json` to report installed-patch state. Mage-OS users have no `repo.magento.com` credentials, and reporting patch state to Adobe's registry is not appropriate for this distribution.
- Being minified, it is neither reviewable nor maintainable.

None of the security fixes above depend on it.

## Notes for review

- The two new files retain their upstream `Copyright 2026 Adobe / All Rights Reserved.` headers verbatim.
- The one-character `Sanitizer.php` change is easy to overlook but is a real bypass fix — worth a second look.
- The upstream patch ships no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)