### PR TITLE
Fix AMQP consumer busy-loop at 100% CPU on idle queue

### DIFF
--- a/lib/internal/Magento/Framework/Amqp/Queue.php
+++ b/lib/internal/Magento/Framework/Amqp/Queue.php
@@ -180,7 +180,7 @@ class Queue implements QueueInterface
         $channel->basic_qos(0, $this->prefetchCount, false);
         $consumerTag = $channel->basic_consume($this->queueName, '', false, false, false, false, $callbackConverter);
 
-        $timeout = $waitTimeout > 0 ? $waitTimeout : null;
+        $timeout = $waitTimeout > 0 ? $waitTimeout : 0;
         while (count($channel->callbacks)) {
             try {
                 $channel->wait(null, false, $timeout);

--- a/lib/internal/Magento/Framework/Amqp/Test/Unit/QueueTest.php
+++ b/lib/internal/Magento/Framework/Amqp/Test/Unit/QueueTest.php
@@ -183,4 +183,37 @@ class QueueTest extends TestCase
         $this->model->subscribeWithLimit(function () {
         }, 10, 1);
     }
+
+    /**
+     * Test verifies a waitTimeout of 0 ("block indefinitely", used when
+     * consumers_wait_for_messages=1) is forwarded to $channel->wait() as the
+     * integer 0 and never as null. php-amqplib maps a null wait timeout onto
+     * stream_select() with a zero timeval — a non-blocking poll — which turns an
+     * idle consumer into a 100% CPU busy-loop. Passing 0 blocks until a frame
+     * arrives, matching the sibling subscribe() method.
+     */
+    public function testSubscribeWithLimitPassesZeroTimeoutSoWaitBlocks(): void
+    {
+        $amqpChannel = $this->createMock(AMQPChannel::class);
+        $amqpChannel->method('basic_qos');
+        $amqpChannel->method('basic_consume')
+            ->willReturnCallback(function () use ($amqpChannel) {
+                $amqpChannel->callbacks = ['test-consumer-tag' => function () {
+                }];
+                return 'test-consumer-tag';
+            });
+        // identicalTo enforces === so a null timeout fails the expectation
+        // (with()'s default equalTo would let null pass, since null == 0 in PHP).
+        $amqpChannel->expects($this->once())
+            ->method('wait')
+            ->with(null, false, $this->identicalTo(0))
+            ->willReturnCallback(function () use ($amqpChannel) {
+                // Simulate basic_cancel emptying callbacks so the while loop ends.
+                $amqpChannel->callbacks = [];
+            });
+        $this->config->method('getChannel')->willReturn($amqpChannel);
+
+        $this->model->subscribeWithLimit(function () {
+        }, 10, 0);
+    }
 }


### PR DESCRIPTION
### Description (*)

`Magento\Framework\Amqp\Queue::subscribeWithLimit()` passes `null` as the wait timeout to `AMQPChannel::wait()` when the consumer is meant to block.

When `consumers_wait_for_messages=1` (the default), `CallbackInvoker::invokeAmqp()` calls `subscribeWithLimit()` with `$waitTimeout = 0`, meaning "block indefinitely". That `0` is then turned into `null`:

```php
$timeout = $waitTimeout > 0 ? $waitTimeout : null;   // 0 -> null
while (count($channel->callbacks)) {
    try {
        $channel->wait(null, false, $timeout);
    } catch (AMQPTimeoutException $e) {
        break;
    }
}
```

php-amqplib maps a `null` wait timeout onto `stream_select(..., 0, 0)` — a **non-blocking poll**. So a consumer sitting on an idle queue spins `pselect6(..., {tv_sec=0, tv_nsec=0})` at ~50k calls/s, pinning a full CPU core at ~100% indefinitely. Because it never processes a real message, `--max-messages` never recycles it, so the busy-loop runs until the process is killed.

The sibling `subscribe()` method calls `wait()` with the default timeout of `0`, which php-amqplib treats as "block until a frame arrives" — the correct behaviour. This PR aligns `subscribeWithLimit()` with it: pass `0`, not `null`.

```diff
-        $timeout = $waitTimeout > 0 ? $waitTimeout : null;
+        $timeout = $waitTimeout > 0 ? $waitTimeout : 0;
```

A unit test is added asserting `wait()` receives an identical integer `0` (not `null`) when `waitTimeout = 0`. It uses `identicalTo(0)` deliberately: the default `equalTo` matcher would let `null` pass, since `null == 0` is `true` in PHP.

### Related Pull Requests

Regression introduced by #213 (*Replace basic_get polling with basic_consume push for AMQP consumers*), which added the push-based `subscribeWithLimit()` / `CallbackInvoker::invokeAmqp()` code path.

### Manual testing scenarios (*)

Reproducing the busy-loop:

1. On a Mage-OS 3.1 install with AMQP (RabbitMQ) configured and `consumers_wait_for_messages=1` (the default), ensure a message-queue consumer's queue is **empty/idle**.
2. Start the consumer: `bin/magento queue:consumers:start <consumer_name> --max-messages=10000`.
3. Observe that the process pins ~100% of a CPU core even though no messages are being processed. `strace -c -p <pid>` shows `pselect6` called tens of thousands of times per second with a `{tv_sec=0, tv_nsec=0}` timeout (a non-blocking poll):
   ```
   % time     calls    syscall
   100.00   150,392    pselect6
   ```

Verifying the fix:

4. With the patch applied, restart the consumer against the same idle queue.
5. The process now sits at ~0% CPU in interruptible sleep (state `S`); `strace` shows `pselect6(..., NULL, NULL)` — a blocking wait that wakes only when a frame arrives:
   ```
   pselect6(9, [8], [], [], NULL, NULL)
   ```
6. Publish a message to the queue and confirm the consumer still processes it immediately (no added latency).

Automated coverage:

7. `vendor/bin/phpunit lib/internal/Magento/Framework/Amqp/Test/Unit/QueueTest.php` — the new `testSubscribeWithLimitPassesZeroTimeoutSoWaitBlocks` fails on the current code (`null` is not identical to `0`) and passes with the fix; the rest of the suite stays green.
