### PR TITLE
Fix Redis unix socket connections in SymfonyAdapterProvider (silent filesystem fallback)

### DIFF
--- a/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapterProvider.php
+++ b/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapterProvider.php
@@ -381,15 +381,43 @@ class SymfonyAdapterProvider implements ResetAfterRequestInterface
         }
 
         // Build base DSN
-        $baseDsn = $password
-            ? sprintf('redis://%s@%s:%d/%d', urlencode($password), $host, $port, $database)
-            : sprintf('redis://%s:%d/%d', $host, $port, $database);
+        $baseDsn = $this->buildRedisBaseDsn($host, $port, $database, $password);
 
         // Append DSN parameters
         $dsn = $dsnParams ? $baseDsn . '?' . implode('&', $dsnParams) : $baseDsn;
 
         // Create and return the connection using Symfony's factory
         return RedisAdapter::createConnection($dsn);
+    }
+
+    /**
+     * Build the base Redis DSN for a TCP host or a unix socket path
+     *
+     * A host beginning with '/' is treated as a unix socket path, matching the
+     * convention used by phpredis and Credis (the backends behind the previous
+     * Zend-based Redis cache implementation). Symfony's socket DSN format is
+     * redis://[auth@]/path/to/redis.sock/<dbindex> - appending ':<port>' to a
+     * socket path would make Symfony resolve a non-existent socket file.
+     *
+     * @param string $host Hostname, IP address, or unix socket path
+     * @param int $port TCP port (ignored for unix sockets)
+     * @param int $database Redis database index
+     * @param string|null $password Optional AUTH password
+     * @return string
+     */
+    private function buildRedisBaseDsn(
+        string $host,
+        int $port,
+        int $database,
+        ?string $password
+    ): string {
+        $auth = $password !== null && $password !== '' ? rawurlencode($password) . '@' : '';
+
+        if (str_starts_with($host, '/')) {
+            return sprintf('redis://%s%s/%d', $auth, $host, $database);
+        }
+
+        return sprintf('redis://%s%s:%d/%d', $auth, $host, $port, $database);
     }
 
     /**
@@ -414,22 +442,51 @@ class SymfonyAdapterProvider implements ResetAfterRequestInterface
         ?float $timeout,
         ?float $readTimeout
     ) {
-        $params = [
-            'scheme' => 'tcp',
-            'host' => $host,
-            'port' => $port,
-            'database' => $database,
-        ];
-
-        if ($password) {
-            $params['password'] = $password;
-        }
+        $params = $this->buildPredisConnectionParameters($host, $port, $database, $password);
 
         $options = [
             'exceptions' => false,
         ];
 
         return new OptimizedPredisClient($params, $options);
+    }
+
+    /**
+     * Build Predis connection parameters for a TCP host or a unix socket path
+     *
+     * @param string $host Hostname, IP address, or unix socket path
+     * @param int $port TCP port (ignored for unix sockets)
+     * @param int $database Redis database index
+     * @param string|null $password Optional AUTH password
+     * @return array
+     */
+    private function buildPredisConnectionParameters(
+        string $host,
+        int $port,
+        int $database,
+        ?string $password
+    ): array {
+        if (str_starts_with($host, '/')) {
+            // Unix socket connection
+            $params = [
+                'scheme' => 'unix',
+                'path' => $host,
+                'database' => $database,
+            ];
+        } else {
+            $params = [
+                'scheme' => 'tcp',
+                'host' => $host,
+                'port' => $port,
+                'database' => $database,
+            ];
+        }
+
+        if ($password) {
+            $params['password'] = $password;
+        }
+
+        return $params;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Adapter/SymfonyAdapterProviderTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Adapter/SymfonyAdapterProviderTest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Cache\Test\Unit\Frontend\Adapter;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Cache\Frontend\Adapter\SymfonyAdapterProvider;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Serialize\Serializer\Serialize;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit test for SymfonyAdapterProvider Redis connection configuration
+ */
+class SymfonyAdapterProviderTest extends TestCase
+{
+    /**
+     * @var SymfonyAdapterProvider
+     */
+    private SymfonyAdapterProvider $provider;
+
+    /**
+     * Set up test environment
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->provider = new SymfonyAdapterProvider(
+            $this->createStub(Filesystem::class),
+            $this->createStub(ResourceConnection::class),
+            $this->createStub(Serialize::class)
+        );
+    }
+
+    /**
+     * Test base DSN construction for TCP hosts and unix socket paths
+     *
+     * @param string $host
+     * @param int $port
+     * @param int $database
+     * @param string|null $password
+     * @param string $expectedDsn
+     */
+    #[DataProvider('redisBaseDsnDataProvider')]
+    public function testBuildRedisBaseDsn(
+        string $host,
+        int $port,
+        int $database,
+        ?string $password,
+        string $expectedDsn,
+    ): void {
+        $dsn = $this->invokePrivateMethod(
+            'buildRedisBaseDsn',
+            [$host, $port, $database, $password]
+        );
+
+        $this->assertSame($expectedDsn, $dsn);
+    }
+
+    /**
+     * Data provider for testBuildRedisBaseDsn
+     *
+     * @return array
+     */
+    public static function redisBaseDsnDataProvider(): array
+    {
+        return [
+            'tcp host without auth' => [
+                '127.0.0.1',
+                6379,
+                2,
+                null,
+                'redis://127.0.0.1:6379/2',
+            ],
+            'tcp host with auth' => [
+                'redis.internal',
+                6380,
+                1,
+                'secret',
+                'redis://secret@redis.internal:6380/1',
+            ],
+            'tcp host with empty password' => [
+                '127.0.0.1',
+                6379,
+                0,
+                '',
+                'redis://127.0.0.1:6379/0',
+            ],
+            'password with reserved characters is url-encoded' => [
+                '127.0.0.1',
+                6379,
+                0,
+                'p@ss:w/rd 1',
+                'redis://p%40ss%3Aw%2Frd%201@127.0.0.1:6379/0',
+            ],
+            'unix socket without auth' => [
+                '/var/run/redis/redis.sock',
+                0,
+                1,
+                null,
+                'redis:///var/run/redis/redis.sock/1',
+            ],
+            'unix socket with auth' => [
+                '/var/run/redis/redis.sock',
+                0,
+                3,
+                'secret',
+                'redis://secret@/var/run/redis/redis.sock/3',
+            ],
+            'unix socket ignores configured port' => [
+                '/var/run/redis-multi.redis/redis.sock',
+                6379,
+                0,
+                null,
+                'redis:///var/run/redis-multi.redis/redis.sock/0',
+            ],
+        ];
+    }
+
+    /**
+     * Test Predis connection parameters for TCP hosts and unix socket paths
+     *
+     * @param string $host
+     * @param int $port
+     * @param int $database
+     * @param string|null $password
+     * @param array $expectedParams
+     */
+    #[DataProvider('predisConnectionParametersDataProvider')]
+    public function testBuildPredisConnectionParameters(
+        string $host,
+        int $port,
+        int $database,
+        ?string $password,
+        array $expectedParams,
+    ): void {
+        $params = $this->invokePrivateMethod(
+            'buildPredisConnectionParameters',
+            [$host, $port, $database, $password]
+        );
+
+        $this->assertSame($expectedParams, $params);
+    }
+
+    /**
+     * Data provider for testBuildPredisConnectionParameters
+     *
+     * @return array
+     */
+    public static function predisConnectionParametersDataProvider(): array
+    {
+        return [
+            'tcp host without auth' => [
+                '127.0.0.1',
+                6379,
+                2,
+                null,
+                [
+                    'scheme' => 'tcp',
+                    'host' => '127.0.0.1',
+                    'port' => 6379,
+                    'database' => 2,
+                ],
+            ],
+            'tcp host with auth' => [
+                'redis.internal',
+                6380,
+                1,
+                'secret',
+                [
+                    'scheme' => 'tcp',
+                    'host' => 'redis.internal',
+                    'port' => 6380,
+                    'database' => 1,
+                    'password' => 'secret',
+                ],
+            ],
+            'unix socket without auth' => [
+                '/var/run/redis/redis.sock',
+                0,
+                1,
+                null,
+                [
+                    'scheme' => 'unix',
+                    'path' => '/var/run/redis/redis.sock',
+                    'database' => 1,
+                ],
+            ],
+            'unix socket with auth' => [
+                '/var/run/redis/redis.sock',
+                0,
+                0,
+                'secret',
+                [
+                    'scheme' => 'unix',
+                    'path' => '/var/run/redis/redis.sock',
+                    'database' => 0,
+                    'password' => 'secret',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Invoke a private method on the provider under test
+     *
+     * @param string $methodName
+     * @param array $arguments
+     * @return mixed
+     */
+    private function invokePrivateMethod(string $methodName, array $arguments): mixed
+    {
+        $method = new \ReflectionMethod($this->provider, $methodName);
+
+        return $method->invokeArgs($this->provider, $arguments);
+    }
+}


### PR DESCRIPTION
### Summary

Since the Symfony cache migration, configuring the Redis cache backend with a unix socket in `env.php` silently falls back to the filesystem adapter — cache and FPC quietly stop using Redis with no error or log entry.

### Root cause

`SymfonyAdapterProvider::createPhpRedisConnection()` builds the DSN as `redis://host:port/db` unconditionally:

```php
$baseDsn = $password
    ? sprintf('redis://%s@%s:%d/%d', urlencode($password), $host, $port, $database)
    : sprintf('redis://%s:%d/%d', $host, $port, $database);
```

With a typical socket config (`'server' => '/var/run/redis/redis.sock', 'port' => '0'`) this yields:

```
redis:///var/run/redis/redis.sock:0/1
```

Symfony's `RedisTrait::createConnection()` strips the trailing `/1` as the dbindex and resolves the unix socket file as `/var/run/redis/redis.sock:0` — which doesn't exist. The connection failure is then swallowed by `createAdapter()`'s catch-all `\Exception` handler, which falls back to `createFilesystemAdapter()` without logging, so the misconfiguration is invisible unless you notice Redis is empty and `var/cache/` is growing.

The Predis fallback path (`createOptimizedPredisConnection()`) has the same gap: it always builds `scheme => tcp` parameters.

### Fix

Treat a host beginning with `/` as a unix socket path — the same convention used by phpredis's `connect()` and by Credis behind the previous Zend-based `Magento\Framework\Cache\Backend\Redis`, so socket configs that worked before the Symfony migration work again unchanged — and emit Symfony's documented socket DSN form:

```
redis://[auth@]/path/to/redis.sock/<dbindex>
```

The Predis parameter builder likewise emits `scheme => unix, path => ...` for socket hosts. A hostname can never begin with `/` (DNS labels are letters/digits/hyphens), so the check cannot misroute TCP configs.

Minor related correction: the password is now `rawurlencode()`d rather than `urlencode()`d, matching the `rawurldecode()` Symfony applies when parsing DSN userinfo (differs only for passwords containing spaces).

### Testing

DSN construction and Predis connection parameters are extracted into small private builder methods (`buildRedisBaseDsn()`, `buildPredisConnectionParameters()`) — behavior is otherwise unchanged — and covered by a new unit test, `SymfonyAdapterProviderTest`, with cases for TCP and socket hosts, with/without auth, password encoding of reserved characters, and port being ignored for sockets.

```
OK (11 tests, 11 assertions)
```

Verified on a production Mage-OS 3.2 site using socket-only Redis (`'backend' => 'redis'`, `'server' => '/var/run/redis-multi-*.redis/redis.sock'`): before the fix, cache/FPC fell back to files; with the corrected DSN form, Redis is used.

### Related

The silent catch-all fallback in `createAdapter()` deserves at least a log line — happy to follow up separately if there's interest, since it turns any Redis misconfiguration into an invisible performance regression.

https://claude.ai/code/session_01P3sNFogqGEN5gDbY42sDvE