### PR TITLE
Fix review snippet: emit review author as a schema.org/Person object

### DIFF
--- a/app/code/Magento/Review/view/frontend/templates/product/view/list.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/product/view/list.phtml
@@ -68,7 +68,10 @@ $format = $block->getDateFormat() ?: \IntlDateFormatter::SHORT;
                                     <span class="review-details-label">
                                         <?= $escaper->escapeHtml(__('Review by')) ?>
                                     </span>
-                                    <strong class="review-details-value" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                                    <strong class="review-details-value"
+                                            itemprop="author"
+                                            itemscope
+                                            itemtype="http://schema.org/Person">
                                         <span itemprop="name"><?= $escaper->escapeHtml($_review->getNickname()) ?></span>
                                     </strong>
                                 </p>

--- a/app/code/Magento/Review/view/frontend/templates/product/view/list.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/product/view/list.phtml
@@ -68,8 +68,8 @@ $format = $block->getDateFormat() ?: \IntlDateFormatter::SHORT;
                                     <span class="review-details-label">
                                         <?= $escaper->escapeHtml(__('Review by')) ?>
                                     </span>
-                                    <strong class="review-details-value" itemprop="author">
-                                        <?= $escaper->escapeHtml($_review->getNickname()) ?>
+                                    <strong class="review-details-value" itemprop="author" itemscope itemtype="http://schema.org/Person">
+                                        <span itemprop="name"><?= $escaper->escapeHtml($_review->getNickname()) ?></span>
                                     </strong>
                                 </p>
                                 <p class="review-date">

--- a/app/code/Magento/Review/view/frontend/templates/product/view/list.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/product/view/list.phtml
@@ -72,7 +72,9 @@ $format = $block->getDateFormat() ?: \IntlDateFormatter::SHORT;
                                             itemprop="author"
                                             itemscope
                                             itemtype="http://schema.org/Person">
-                                        <span itemprop="name"><?= $escaper->escapeHtml($_review->getNickname()) ?></span>
+                                        <span itemprop="name">
+                                            <?= $escaper->escapeHtml($_review->getNickname()) ?>
+                                        </span>
                                     </strong>
                                 </p>
                                 <p class="review-date">


### PR DESCRIPTION
### Summary

On the product page, the customer reviews list renders each review's `author` as a **plain text string** (the reviewer nickname) on an element carrying `itemprop="author"`, inside a `schema.org/Review` item. Per schema.org and Google's Review structured-data documentation, a `Review`'s `author` must be a **`Person`** or **`Organization`** object, not text. Google Search Console reports the non-critical Review snippets issue **"Invalid object type for field author"**, and the page is not eligible for an author-based review snippet.

### Root cause

`app/code/Magento/Review/view/frontend/templates/product/view/list.phtml` places `itemprop="author"` directly on a `<strong>` whose content is the nickname text:

```php
<strong class="review-details-value" itemprop="author">
    <?= $escaper->escapeHtml($_review->getNickname()) ?>
</strong>
```

The enclosing `<li>` is `itemscope itemtype="http://schema.org/Review"`, so `author` resolves to `Text` where an object type is expected. Google's [Review snippet doc](https://developers.google.com/search/docs/appearance/structured-data/review-snippet) lists `author` under **Required properties** as `Person` or `Organization`, and its recommended Microdata/RDFa example nests the name inside the author object:

```html
<span property="author" typeof="Person"><span property="name">Bob Smith</span></span>
```

### Fix

Wrap the nickname as a `schema.org/Person` with a nested `itemprop="name"`, so `author` is a valid object type:

```php
<strong class="review-details-value" itemprop="author" itemscope itemtype="http://schema.org/Person">
    <span itemprop="name"><?= $escaper->escapeHtml($_review->getNickname()) ?></span>
</strong>
```

- `http://schema.org/Person` matches the `itemtype` scheme already used by the surrounding `Review`/`Rating` items in the same template (both `http` and `https` are accepted by Google).
- The nickname still flows through `$escaper->escapeHtml(...)`; the only added markup is a static `<span>`, so the reviewer name renders identically on screen.
- The nested `itemprop="name"` binds to the `Person` scope, distinct from the `Review`'s own title `itemprop="name"` a few lines above (which stays in the `Review` scope).
- This is the only `Magento_Review` frontend template that emits `itemprop="author"` (`view.phtml`, `customer/recent.phtml`, `customer/list.phtml`, `product/view/other.phtml` have none), so no other template is affected.

### Testing

Markup-only `.phtml` change with no PHP/behavioral change, so no automated test is added (core templates have no test surface for microdata output). Verified with Google's [Rich Results Test](https://search.google.com/test/rich-results) / [Schema Markup Validator](https://validator.schema.org/) on a product with at least one approved review:

- **Before:** the review's `author` is plain text — `<strong itemprop="author">Jane</strong>` — and the validator/GSC reports *"Invalid object type for field author"*.
- **After:** `author` is a `Person` object — `<strong itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">Jane</span></strong>` — the validator recognizes `author` → `Person` → `name`, and the issue is resolved.
- Rating, `datePublished`, `description`, and the review title microdata are unchanged.

### Related

Same fix submitted upstream to magento/magento2: https://github.com/magento/magento2/pull/41009
