### PR TITLE
Fix PHP 8.5 null array_key_exists deprecation in Captcha getCaptcha

### DIFF
--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -20,27 +20,27 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Used for "name" attribute of captcha's input field
      */
-    const INPUT_NAME_FIELD_VALUE = 'captcha';
+    public const INPUT_NAME_FIELD_VALUE = 'captcha';
 
     /**
      * Always show captcha
      */
-    const MODE_ALWAYS = 'always';
+    public const MODE_ALWAYS = 'always';
 
     /**
      * Show captcha only after certain number of unsuccessful attempts
      */
-    const MODE_AFTER_FAIL = 'after_fail';
+    public const MODE_AFTER_FAIL = 'after_fail';
 
     /**
      * Captcha fonts path
      */
-    const XML_PATH_CAPTCHA_FONTS = 'captcha/fonts';
+    public const XML_PATH_CAPTCHA_FONTS = 'captcha/fonts';
 
     /**
      * Default captcha type
      */
-    const DEFAULT_CAPTCHA_TYPE = 'Zend';
+    public const DEFAULT_CAPTCHA_TYPE = 'Zend';
 
     /**
      * List uses Models of Captcha
@@ -84,11 +84,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Get Captcha
      *
-     * @param string $formId
+     * @param string|null $formId
      * @return \Magento\Captcha\Model\CaptchaInterface
      */
     public function getCaptcha($formId)
     {
+        $formId = $formId ?? '';
         if (!array_key_exists($formId, $this->_captcha)) {
             $captchaType = ucfirst($this->getConfig('type'));
             if (!$captchaType) {

--- a/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
+++ b/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
@@ -91,6 +91,10 @@ class AjaxLogin
         $captchaString = $loginParams[$captchaInputName] ?? null;
         $loginFormId = $loginParams[$captchaFormIdField] ?? null;
 
+        if ($loginFormId === null) {
+            return $proceed();
+        }
+
         if (!in_array($loginFormId, $this->formIds) && $this->helper->getCaptcha($loginFormId)->isRequired($username)) {
             return $this->returnJsonError(__('Provided form does not exist'));
         }

--- a/app/code/Magento/Captcha/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Helper/DataTest.php
@@ -87,7 +87,8 @@ class DataTest extends TestCase
         )->method(
             'create'
         )->with(
-            'Zend'
+            'Zend',
+            'user_create'
         )->willReturn(
             new DefaultModel(
                 $this->createMock(SessionManager::class),
@@ -100,6 +101,33 @@ class DataTest extends TestCase
         );
 
         $this->assertInstanceOf(DefaultModel::class, $this->helper->getCaptcha('user_create'));
+    }
+
+    /**
+     * @covers \Magento\Captcha\Helper\Data::getCaptcha
+     */
+    public function testGetCaptchaWithNullFormId()
+    {
+        $this->configMock->expects($this->once())
+            ->method('getValue')
+            ->with('customer/captcha/type')
+            ->willReturn('zend');
+
+        $this->factoryMock->expects($this->once())
+            ->method('create')
+            ->with('Zend', $this->identicalTo(''))
+            ->willReturn(
+                new DefaultModel(
+                    $this->createMock(SessionManager::class),
+                    $this->createMock(Data::class),
+                    $this->createPartialMock(LogFactory::class, ['create']),
+                    '',                       // null formId coalesced to ''
+                    $this->createMock(Random::class),
+                    $this->createMock(UserContextInterface::class)
+                )
+            );
+
+        $this->assertInstanceOf(DefaultModel::class, $this->helper->getCaptcha(null));
     }
 
     /**

--- a/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
@@ -95,7 +95,7 @@ class AjaxLoginTest extends TestCase
             ->willReturn($this->requestMock);
 
         $this->captchaHelperMock
-            ->expects($this->exactly(1))
+            ->expects($this->any())
             ->method('getCaptcha')
             ->willReturn($this->captchaMock);
 
@@ -193,7 +193,11 @@ class AjaxLoginTest extends TestCase
         $this->serializerMock->expects($this->once())->method('unserialize')
             ->willReturn($requestContent);
 
-        $this->captchaMock->expects($this->once())->method('isRequired')->with($username)
+        $expectEarlyReturn = !array_key_exists('captcha_form_id', $requestContent)
+            || $requestContent['captcha_form_id'] === null;
+        $this->captchaMock
+            ->expects($expectEarlyReturn ? $this->never() : $this->once())
+            ->method('isRequired')->with($username)
             ->willReturn(false);
         $expectLogAttempt = $requestContent['captcha_form_id'] ?? false;
         $this->captchaMock


### PR DESCRIPTION
## Description

On PHP 8.5, the ajax-login flow triggers a hard error:

> `ErrorException: Using null as the key parameter for array_key_exists() is deprecated, use an empty string instead`

`Magento\Captcha\Model\Customer\Plugin\AjaxLogin` reads the form id from request data (`$loginParams['captcha_form_id'] ?? null`) and passes it to `Data::getCaptcha()`. When the request has no `captcha_form_id`, the value is `null`, which reaches `array_key_exists($formId, $this->_captcha)` and, on PHP 8.5, raises the deprecation — a 500 error in developer mode.

## Fix

This PR adopts the upstream Magento solution (magento/magento2#40874), which is more complete than the original single-file cast:

- **`Helper/Data.php`** — normalize a `null` form id to `''` at the top of `getCaptcha()` (`$formId = $formId ?? ''`). This is the single convergence point for all `getCaptcha()` call sites, so one edit hardens every entry path. Behavior is unchanged: PHP has always coerced a `null` array key to `''`, so the internal `$this->_captcha` cache keys are identical. The `@param` is updated to `string|null`.
- **`Model/Customer/Plugin/AjaxLogin.php`** — return early via `$proceed()` when `captcha_form_id` is absent, so the plugin no longer feeds `null` downstream. This matches the pre-existing behavior for a missing form id (the enforcement loop is keyed on configured form ids and never matched a null), it just avoids the PHP 8.5 crash.
- **`Helper/Data.php` constants** — add explicit `public` visibility to the `Data` class constants for PHP 8.5 alignment.

## Backward compatibility

No BC impact. The public `getCaptcha()` signature is unchanged; a null form id resolves to the empty-string key instead of raising a deprecation. Making the already-effectively-public constants explicitly `public` is not a BC break.

## Tests

- `DataTest::testGetCaptchaWithNullFormId` — asserts a `null` form id resolves without deprecation and returns a captcha model, and that the factory receives `''`.
- `AjaxLoginTest` — updated to cover the early-return path when `captcha_form_id` is missing/null.

## Credit

Cherry-pick of the upstream fix by @dimadidr — magento/magento2#40874.

Fixes #295
