### PR TITLE
Fix #299: setup:di:compile truncates non-first area plugin-lists

### DIFF
--- a/lib/internal/Magento/Framework/Interception/PluginListGenerator.php
+++ b/lib/internal/Magento/Framework/Interception/PluginListGenerator.php
@@ -129,7 +129,12 @@ class PluginListGenerator implements ConfigWriterInterface, ConfigLoaderInterfac
                     [$this->pluginData, $this->inherited, $this->processed]
                 );
                 // need global & primary scopes plugin data for other scopes
-                if ($scope === 'global') {
+                // Capture the global/primary baseline that every subsequent area is reset to
+                // below. 'primary' is included because getAllScopes() lists it before 'global':
+                // compiling 'primary' first also loads 'global', so the dedicated 'global'
+                // iteration is skipped and this snapshot would otherwise never be taken -
+                // truncating every later area's plugin-list (see mage-os/mageos-magento2#299).
+                if ($scope === 'global' || $scope === 'primary') {
                     $this->globalScopePluginData = $this->pluginData;
                 }
                 if (count($this->scopePriorityScheme) > 2) {

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/PluginListGeneratorTest.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/PluginListGeneratorTest.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Copyright 2026 Mage-OS
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Interception\Test\Unit;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Config\ReaderInterface;
+use Magento\Framework\Config\ScopeInterface;
+use Magento\Framework\Interception\ConfigInterface as InterceptionConfigInterface;
+use Magento\Framework\Interception\Definition\Runtime as InterceptionDefinitionRuntime;
+use Magento\Framework\Interception\ObjectManager\ConfigInterface;
+use Magento\Framework\Interception\PluginListGenerator;
+use Magento\Framework\Interception\Test\Unit\Custom\Module\Model\Item;
+use Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemPlugin\Simple as ItemPluginSimple;
+use Magento\Framework\ObjectManager\ConfigCacheInterface;
+use Magento\Framework\ObjectManager\DefinitionInterface as ClassDefinitionsInterface;
+use Magento\Framework\ObjectManager\Relations\Runtime as RelationsRuntime;
+use Magento\Framework\ObjectManager\RelationsInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+require_once __DIR__ . '/Custom/Module/Model/Item.php';
+require_once __DIR__ . '/Custom/Module/Model/ItemPlugin/Simple.php';
+
+/**
+ * Regression test for mage-os/mageos-magento2#299.
+ *
+ * A plugin declared in the *global* scope must end up in the compiled
+ * plugin-list of *every* area, not just the first area processed. The
+ * DI-compile "area order" change made setup:di:compile truncate the
+ * plugin-list of every area except the first, dropping global plugins in
+ * (most visibly) the `graphql` area.
+ */
+class PluginListGeneratorTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/plugin_list_generator_test_' . uniqid('', true);
+        mkdir($this->tmpDir . '/generated/metadata', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmpDir . '/generated/metadata/*.php') ?: [] as $file) {
+            unlink($file);
+        }
+        @rmdir($this->tmpDir . '/generated/metadata');
+        @rmdir($this->tmpDir . '/generated');
+        @rmdir($this->tmpDir);
+    }
+
+    /**
+     * Compiles the standard Magento area set (the exact order returned by
+     * ScopeInterface::getAllScopes()) with a single global plugin on Item,
+     * then asserts that plugin survives into every compiled area.
+     */
+    public function testGlobalPluginIsCompiledIntoEveryArea(): void
+    {
+        // Same scope set/order a real install yields from getAllScopes().
+        $scopes = ['primary', 'global', 'frontend', 'adminhtml', 'graphql', 'crontab', 'webapi_rest', 'webapi_soap'];
+
+        $this->createGenerator()->write($scopes);
+
+        $areasMissingGlobalPlugin = [];
+        foreach (glob($this->tmpDir . '/generated/metadata/*|plugin-list.php') as $file) {
+            [$pluginData, $inherited] = include $file;
+            $hasGlobalPlugin = isset($pluginData[Item::class]) || isset($inherited[Item::class]);
+            if (!$hasGlobalPlugin) {
+                $areasMissingGlobalPlugin[] = basename($file, '|plugin-list.php');
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $areasMissingGlobalPlugin,
+            'Global plugin on Item is missing from these compiled area plugin-lists: '
+            . implode(', ', $areasMissingGlobalPlugin)
+        );
+    }
+
+    /**
+     * @return PluginListGenerator
+     */
+    private function createGenerator(): PluginListGenerator
+    {
+        $reader = new class implements ReaderInterface {
+            public function read($scope = null)
+            {
+                if ($scope === 'global') {
+                    return [
+                        Item::class => [
+                            'plugins' => [
+                                'simple_plugin' => [
+                                    'sortOrder' => 10,
+                                    'instance' => ItemPluginSimple::class,
+                                ],
+                            ],
+                        ],
+                    ];
+                }
+                return [];
+            }
+        };
+
+        $scopeConfig = new class implements ScopeInterface {
+            private $currentScope = 'global';
+            public function getCurrentScope()
+            {
+                return $this->currentScope;
+            }
+            public function setCurrentScope($scope)
+            {
+                $this->currentScope = $scope;
+            }
+        };
+
+        $omConfig = new class implements ConfigInterface {
+            public function setInterceptionConfig(InterceptionConfigInterface $interceptionConfig)
+            {
+            }
+            public function getOriginalInstanceType($instanceName)
+            {
+                return $instanceName;
+            }
+            public function setRelations(RelationsInterface $relations)
+            {
+            }
+            public function setCache(ConfigCacheInterface $cache)
+            {
+            }
+            public function getArguments($type)
+            {
+                return [];
+            }
+            public function isShared($type)
+            {
+                return true;
+            }
+            public function getInstanceType($instanceName)
+            {
+                return $instanceName;
+            }
+            public function getPreference($type)
+            {
+                return $type;
+            }
+            public function getVirtualTypes()
+            {
+                return [];
+            }
+            public function extend(array $configuration)
+            {
+            }
+            public function getPreferences()
+            {
+                return [];
+            }
+        };
+
+        $classDefinitions = new class implements ClassDefinitionsInterface {
+            public function getParameters($className)
+            {
+                return [];
+            }
+            public function getClasses()
+            {
+                return [Item::class];
+            }
+        };
+
+        return new PluginListGenerator(
+            $reader,
+            $scopeConfig,
+            $omConfig,
+            new RelationsRuntime(),
+            new InterceptionDefinitionRuntime(),
+            $classDefinitions,
+            new NullLogger(),
+            new DirectoryList($this->tmpDir),
+            ['global'],
+            'production'
+        );
+    }
+}

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/PluginListGeneratorTest.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/PluginListGeneratorTest.php
@@ -53,9 +53,17 @@ class PluginListGeneratorTest extends TestCase
         foreach (glob($this->tmpDir . '/generated/metadata/*.php') ?: [] as $file) {
             unlink($file);
         }
-        @rmdir($this->tmpDir . '/generated/metadata');
-        @rmdir($this->tmpDir . '/generated');
-        @rmdir($this->tmpDir);
+        foreach (
+            [
+                $this->tmpDir . '/generated/metadata',
+                $this->tmpDir . '/generated',
+                $this->tmpDir,
+            ] as $dir
+        ) {
+            if (is_dir($dir)) {
+                rmdir($dir);
+            }
+        }
     }
 
     /**
@@ -112,6 +120,9 @@ class PluginListGeneratorTest extends TestCase
         };
 
         $scopeConfig = new class implements ScopeInterface {
+            /**
+             * @var string
+             */
             private $currentScope = 'global';
             public function getCurrentScope()
             {

--- a/lib/internal/Magento/Framework/Test/Unit/Interception/PluginListGeneratorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Interception/PluginListGeneratorTest.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\Framework\Interception\Test\Unit;
+namespace Magento\Framework\Test\Unit\Interception;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Config\ReaderInterface;
@@ -23,8 +23,8 @@ use Magento\Framework\ObjectManager\RelationsInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
-require_once __DIR__ . '/Custom/Module/Model/Item.php';
-require_once __DIR__ . '/Custom/Module/Model/ItemPlugin/Simple.php';
+require_once __DIR__ . '/../../../Interception/Test/Unit/Custom/Module/Model/Item.php';
+require_once __DIR__ . '/../../../Interception/Test/Unit/Custom/Module/Model/ItemPlugin/Simple.php';
 
 /**
  * Regression test for mage-os/mageos-magento2#299.

--- a/lib/internal/Magento/Framework/Test/Unit/Interception/PluginListGeneratorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Interception/PluginListGeneratorTest.php
@@ -53,13 +53,12 @@ class PluginListGeneratorTest extends TestCase
         foreach (glob($this->tmpDir . '/generated/metadata/*.php') ?: [] as $file) {
             unlink($file);
         }
-        foreach (
-            [
-                $this->tmpDir . '/generated/metadata',
-                $this->tmpDir . '/generated',
-                $this->tmpDir,
-            ] as $dir
-        ) {
+        $dirs = [
+            $this->tmpDir . '/generated/metadata',
+            $this->tmpDir . '/generated',
+            $this->tmpDir,
+        ];
+        foreach ($dirs as $dir) {
             if (is_dir($dir)) {
                 rmdir($dir);
             }


### PR DESCRIPTION
_Opened by **Claude** (Anthropic's Claude Code) on behalf of a Mage-OS 3.2.0 user. Follow-up to the reproduction PR #300; fixes #299._

## Root cause

`PluginListGenerator::write()` compiles each scope in turn. It snapshots the global/primary plugin baseline into `$globalScopePluginData` and, after finishing an area, resets `$pluginData` back to that snapshot before compiling the next area. The snapshot was taken **only** on the `$scope === 'global'` iteration:

```php
if ($scope === 'global') {
    $this->globalScopePluginData = $this->pluginData;
}
```

`ScopeInterface::getAllScopes()` returns `primary` **before** `global`, and the compile task (`…/Operation/PluginListGenerator::doOperation()`) now passes that order verbatim. Compiling `primary` first also loads the `global` scope (it is part of the priority scheme), so the dedicated `global` iteration is skipped via `$loadedScopes` — and the snapshot is **never taken**. `$globalScopePluginData` stays `[]`, so every area after the first is reset to an empty baseline and loses all global plugins.

Net effect (production mode only — developer mode regenerates at runtime): only `global|primary` and the first area (`frontend`) get a complete plugin-list; `graphql`, `adminhtml`, `webapi_*` and `crontab` are truncated. Most visibly this breaks GraphQL attribute filters and aggregations, because the `Magento\Elasticsearch\*` request-building plugins never apply in the `graphql` area.

## Fix

Capture the baseline on the `primary` scope as well:

```php
if ($scope === 'global' || $scope === 'primary') {
    $this->globalScopePluginData = $this->pluginData;
}
```

Now the snapshot is taken whichever of `global`/`primary` is compiled first. The cache-id normalisation that was added for compile/runtime metadata reuse is left untouched, so that optimisation still works.

## Test

Includes `PluginListGeneratorTest::testGlobalPluginIsCompiledIntoEveryArea` (the same test introduced failing in #300). It compiles the real `getAllScopes()` order with one global plugin on the `Item` fixture and asserts the plugin reaches every compiled area. Red before this change, green after.

Verified end-to-end on a real Mage-OS 3.2.0 install: after the fix the `graphql` plugin-list goes from ~50 KB (0 CatalogSearch plugins) to ~445 KB, and GraphQL `filter{sku:{eq}}` / `aggregations` work again.

Fixes #299.