### PR TITLE
Fix #307: PHP 8.5 null array offset deprecation in Data\Form::setValues()

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form.php
+++ b/lib/internal/Magento/Framework/Data/Form.php
@@ -188,8 +188,9 @@ class Form extends \Magento\Framework\Data\Form\AbstractForm
         $elementId = $element->getId();
         if ($elementId !== null) {
             $this->_elementsIndex[$elementId] = $element;
+            $this->_allElements->add($element);
         }
-        $this->_allElements->add($element);
+
         return $this;
     }
 

--- a/lib/internal/Magento/Framework/Data/Test/Unit/FormTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/FormTest.php
@@ -148,4 +148,12 @@ class FormTest extends TestCase
         $this->_form->removeField($buttonElement->getId());
         $this->assertSame($this->_form->checkElementId($buttonElement->getId()), true);
     }
+
+    public function testAddElementWithNoId()
+    {
+        $buttonElement = $this->createStub(Button::class);
+
+        $this->_form->addElementToCollection($buttonElement);
+        $this->_form->setValues(['1', '2', '3']);
+    }
 }


### PR DESCRIPTION
Fixes #307

Cherry-pick of [magento/magento2#41026](https://github.com/magento/magento2/pull/41026) (commit `95d4727`, authored by Pieter Hoste), applied byte-faithfully with authorship preserved.

## Problem

On PHP 8.5, opening or creating a tax rate (**Stores > Taxes > Tax Zones and Rates**) fails with:

> Deprecated Functionality: Using null as an array offset is deprecated, use an empty string instead in `lib/internal/Magento/Framework/Data/Form.php` on line 248

It only reproduces when more than one store view exists.

## Root cause

`Magento\Tax\Block\Adminhtml\Rate\Form::_prepareForm()` adds an ID-less fieldset when the installation is not single-store (`app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php:299`):

```php
if (!$this->_storeManager->hasSingleStore()) {
    $form->addElement($this->_fieldsetFactory->create()->setLegend(__('Tax Titles')));
}
```

`Form::addElementToCollection()` already guarded the `_elementsIndex[$elementId]` write against a null ID, but still pushed the element into `_allElements` unconditionally. `Form::setValues()` then iterates `_allElements` and evaluates `isset($values[$element->getId()])` — a null array offset, which PHP 8.5 deprecates.

## Fix

The defect is in the framework, not in the Tax block. `setValues()`/`addValues()` key elements by ID, so an element with no ID has nothing to look up and does not belong in that collection. Moving the `_allElements->add()` inside the existing null guard fixes the deprecation for every form containing an ID-less element, not just tax rates:

```php
$elementId = $element->getId();
if ($elementId !== null) {
    $this->_elementsIndex[$elementId] = $element;
    $this->_allElements->add($element);
}
```

A legend-only fieldset legitimately has no ID and `addElement()` never required one, so patching the Tax block to invent an ID would have been a symptom fix that left every other ID-less-element form broken.

## Backward compatibility

No BC impact. `_allElements` is read only by `Form::setValues()` and `Form::addValues()`, both purely ID-keyed lookups. Rendering goes through `AbstractForm::$_elements` via `getElements()`, which `Form` does not override — so the "Tax Titles" fieldset still renders. `_allElements` is `protected`, but no core subclass reads it.

## Tests

Adds `FormTest::testAddElementWithNoId()` from the upstream commit, covering `addElementToCollection()` + `setValues()` with an ID-less element.

```
$ php vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist \
    lib/internal/Magento/Framework/Data/Test/Unit/FormTest.php
Tests: 5, Assertions: 11 — OK
```

The upstream test is assertion-less by design — it passes if no deprecation is raised — hence PHPUnit's risky-test notice. Left as-is to keep the cherry-pick faithful.

## Verification notes

Local PHP is 8.4, which does not raise this deprecation, so the failure could not be observed directly here; the no-regression reasoning above is from reading the code paths, and the admin tax rate page was not loaded in a browser to visually confirm the fieldset still renders.

## Upstream status

magento/magento2#41026 is **open, not yet merged** — labelled `Progress: extended testing` / `Priority: P2`, with one community approval, last updated 2026-07-31. Worth re-syncing if the upstream PR changes before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
