### PR TITLE
Fix #306: PHP 8.5 null array offset deprecation in ScopeCodeResolver::resolve()

### DIFF
--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -41,11 +41,8 @@ class ScopeCodeResolver
      */
     public function resolve($scopeType, $scopeCode)
     {
-        // use empty string in case $scopeCode is null, needed to avoid deprecated warnings on PHP >=8.5
-        $scopeCodeKey = $scopeCode ?? '';
-
-        if (isset($this->resolvedScopeCodes[$scopeType][$scopeCodeKey])) {
-            return $this->resolvedScopeCodes[$scopeType][$scopeCodeKey];
+        if ($scopeCode !== null && isset($this->resolvedScopeCodes[$scopeType][$scopeCode])) {
+            return $this->resolvedScopeCodes[$scopeType][$scopeCode];
         }
 
         if ($scopeType !== ScopeConfigInterface::SCOPE_TYPE_DEFAULT) {
@@ -59,7 +56,11 @@ class ScopeCodeResolver
             $resolverScopeCode = $resolverScopeCode->getCode();
         }
 
-        $this->resolvedScopeCodes[$scopeType][$scopeCodeKey] = $resolverScopeCode;
+        if ($scopeCode === null) {
+            return $resolverScopeCode;
+        }
+
+        $this->resolvedScopeCodes[$scopeType][$scopeCode] = $resolverScopeCode;
 
         return $resolverScopeCode;
     }

--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -41,8 +41,11 @@ class ScopeCodeResolver
      */
     public function resolve($scopeType, $scopeCode)
     {
-        if (isset($scopeCode, $this->resolvedScopeCodes[$scopeType][$scopeCode])) {
-            return $this->resolvedScopeCodes[$scopeType][$scopeCode];
+        // use empty string in case $scopeCode is null, needed to avoid deprecated warnings on PHP >=8.5
+        $scopeCodeKey = $scopeCode ?? '';
+
+        if (isset($this->resolvedScopeCodes[$scopeType][$scopeCodeKey])) {
+            return $this->resolvedScopeCodes[$scopeType][$scopeCodeKey];
         }
 
         if ($scopeType !== ScopeConfigInterface::SCOPE_TYPE_DEFAULT) {
@@ -60,7 +63,7 @@ class ScopeCodeResolver
             $scopeCode = $resolverScopeCode;
         }
 
-        $this->resolvedScopeCodes[$scopeType][$scopeCode] = $resolverScopeCode;
+        $this->resolvedScopeCodes[$scopeType][$scopeCodeKey] = $resolverScopeCode;
 
         return $resolverScopeCode;
     }

--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -59,10 +59,6 @@ class ScopeCodeResolver
             $resolverScopeCode = $resolverScopeCode->getCode();
         }
 
-        if ($scopeCode === null) {
-            $scopeCode = $resolverScopeCode;
-        }
-
         $this->resolvedScopeCodes[$scopeType][$scopeCodeKey] = $resolverScopeCode;
 
         return $resolverScopeCode;

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/ScopeCodeResolverTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/ScopeCodeResolverTest.php
@@ -69,4 +69,19 @@ class ScopeCodeResolverTest extends TestCase
             ->willReturn($scopeCode);
         $this->assertEquals($scopeCode, $this->scopeCodeResolver->resolve($scopeType, $scopeId));
     }
+
+    public function testResolveWithScopeCodeNullAndScopeTypeDefault()
+    {
+        $scopeType = 'default';
+        $scopeCode = null;
+
+        $this->scopeResolverPool->expects($this->never())
+            ->method('get');
+        $this->scopeResolver->expects($this->never())
+            ->method('getScope');
+        $this->scope->expects($this->never())
+            ->method('getCode');
+
+        $this->scopeCodeResolver->resolve($scopeType, $scopeCode);
+    }
 }


### PR DESCRIPTION
Fixes #306

Cherry-pick of [magento/magento2#40889](https://github.com/magento/magento2/pull/40889) (authored by Pieter Hoste), applied byte-faithfully with authorship preserved.

## Problem

On PHP 8.5, **Content > Design > Configuration > Edit** on the *Global* scope fails with:

> Deprecated Functionality: Using null as an array offset is deprecated, use an empty string instead in `lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php` on line 62

## Root cause

`Magento\Theme\Model\Design\Config\DataProvider::getMeta()` resolves the scope from request params, passing `null` when there is no `scope_id` (`app/code/Magento/Theme/Model/Design/Config/DataProvider.php:117`):

```php
$scopeCode = $this->getScopeCodeResolver()->resolve(
    $scope,
    isset($request['scope_id']) ? $request['scope_id'] : null
);
```

Editing the Global scope means `scope=default` with no `scope_id`, so `resolve('default', null)` is called. Inside `ScopeCodeResolver::resolve()`:

* `$scopeType === SCOPE_TYPE_DEFAULT`, so `$resolverScopeCode = $scopeCode` — still `null`
* the existing normalisation `if ($scopeCode === null) { $scopeCode = $resolverScopeCode; }` is a no-op here, assigning null to null
* the cache write `$this->resolvedScopeCodes[$scopeType][$scopeCode] = ...` then runs with a null key, which PHP 8.5 deprecates

The read path was already safe — `isset($scopeCode, ...)` short-circuits on the null first argument — which is why the deprecation is reported on line 62 and not line 44.

## Fix

Guard the cache read with an explicit null check and return early instead of caching when the scope code is null:

```php
if ($scopeCode !== null && isset($this->resolvedScopeCodes[$scopeType][$scopeCode])) {
    return $this->resolvedScopeCodes[$scopeType][$scopeCode];
}
...
if ($scopeCode === null) {
    return $resolverScopeCode;
}
$this->resolvedScopeCodes[$scopeType][$scopeCode] = $resolverScopeCode;
```

Three commits are carried over rather than squashed, to keep the cherry-pick faithful to upstream. Commits 2 and 3 are the author's response to review feedback and walk back the `$scopeCode ?? ''` approach taken in commit 1, so only the final state above is effective:

| upstream | subject |
|---|---|
| `8abc1e9` | Avoid PHP 8.5 deprecation, by using empty string for array key instead of null. |
| `71b02fe` | Further cleanup |
| `b035815` | Remove performance optimisations, as they appear to break some tests. |

## Backward compatibility

No API or signature change, but one behaviour change worth calling out: previously a call with `$scopeCode === null` and a *non-default* scope type cached its result under the **resolved** code, so a later `resolve($scopeType, 'thatCode')` would hit that cache entry. Null-scoped calls now return early and never populate the cache, so they re-hit `ScopeResolverPool` each time.

That is a small, deliberate loss of cache warmth — upstream commit `b035815` ("Remove performance optimisations, as they appear to break some tests") is exactly this trade being accepted after review. Correctness is unchanged.

## Tests

Adds `ScopeCodeResolverTest::testResolveWithScopeCodeNullAndScopeTypeDefault()` from the upstream commit, asserting the resolver pool is never consulted for a null scope code under the default scope type.

```
$ php vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist \
    lib/internal/Magento/Framework/App/Test/Unit/Config/ScopeCodeResolverTest.php
Tests: 2, Assertions: 9 — OK
```

## Verification notes

`resolve()` is now byte-identical to upstream `2.4-develop`. The only remaining diff in the file is our own Mage-OS `#[\Magento\Framework\ObjectManager\Attribute\NonLazy]` attribute from the PHP 8.4 lazy-ghost work (`4f3ba0f`), which is unrelated to this fix:

```
$ diff <upstream 2.4-develop> lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
13a14
> #[\Magento\Framework\ObjectManager\Attribute\NonLazy]
```

Local PHP is 8.4, which does not raise this deprecation, so the failure could not be observed directly here — the trigger path was confirmed by tracing the code, and the design configuration page was not loaded in a browser.

## Upstream status

Merged into `2.4-develop` on 2026-07-17. Adobe merged the contributor branch into their internal `AC-17456` branch, which can close a PR as merged without the change reaching the release branch, so this was verified independently:

```
$ gh api repos/magento/magento2/compare/2.4-develop...b035815
{"status": "behind", "ahead_by": 0, "behind_by": 527}
```

`ahead_by: 0` confirms the PR head is a genuine ancestor of `2.4-develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
