### PR TITLE
Fix #302: PHP 8.5 null array offset deprecation for category attributes with null frontend_input

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/DataProvider.php
+++ b/app/code/Magento/Catalog/Model/Category/DataProvider.php
@@ -416,7 +416,7 @@ class DataProvider extends ModifierPoolDataProvider
                     $meta[$code][$metaName] = (bool)$meta[$code][$metaName];
                 }
                 if ('frontend_input' === $origName) {
-                    $meta[$code]['formElement'] = isset($this->formElement[$value])
+                    $meta[$code]['formElement'] = $value !== null && isset($this->formElement[$value])
                         ? $this->formElement[$value]
                         : $value;
                 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/DataProviderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/DataProviderTest.php
@@ -369,4 +369,27 @@ class DataProviderTest extends TestCase
 
         $this->getModel()->getMeta();
     }
+
+    /**
+     * Regression test for https://github.com/magento/magento2/issues/40908
+     *
+     * A category attribute can have a null 'frontend_input'. On PHP 8.5 that made
+     * getAttributesMeta() trigger "Using null as an array offset is deprecated",
+     * so this test should fail when the null check is ever removed.
+     */
+    public function testGetAttributesMetaWithNullFrontendInput()
+    {
+        $attributeMock = $this->createMock(Attribute::class);
+        $attributeMock->method('getAttributeCode')->willReturn('custom_attribute');
+        $attributeMock->method('getDataUsingMethod')->willReturn(null);
+
+        $entityTypeMock = $this->createMock(Type::class);
+        $entityTypeMock->method('getAttributeCollection')->willReturn([$attributeMock]);
+
+        $this->arrayUtils->method('flatten')->willReturn([]);
+
+        $meta = $this->getModel()->getAttributesMeta($entityTypeMock);
+
+        $this->assertNull($meta['custom_attribute']['formElement']);
+    }
 }


### PR DESCRIPTION
Fixes #302

Cherry-pick of [magento/magento2#40894](https://github.com/magento/magento2/pull/40894) (authored by Pieter Hoste), applied byte-faithfully with authorship preserved.

## Problem

On PHP 8.5, opening any category under **Catalog > Categories** in the admin fails with:

> Deprecated Functionality: Using null as an array offset is deprecated, use an empty string instead in `app/code/Magento/Catalog/Model/Category/DataProvider.php` on line 419

This is reproducible with Smile ElasticSuite 2.12.0, which is the case reported in #302.

## Root cause

`Catalog\Model\Category\DataProvider::getAttributesMeta()` maps an attribute's `frontend_input` onto a form element:

```php
if ('frontend_input' === $origName) {
    $meta[$code]['formElement'] = isset($this->formElement[$value])
        ? $this->formElement[$value]
        : $value;
}
```

`$value` comes from `$attribute->getDataUsingMethod('frontend_input')` and is not guaranteed to be set. ElasticSuite creates its category attributes (`is_virtual_category`, `virtual_category_root`, `virtual_rule`) via setup patches without an `input` parameter, which leaves `frontend_input` as NULL in `eav_attribute`. As #302 documents:

```sql
SELECT attribute_id, attribute_code, entity_type_id, frontend_input
FROM eav_attribute
WHERE attribute_code IN ('is_virtual_category', 'virtual_category_root', 'virtual_rule');
-- frontend_input is NULL
```

`isset($this->formElement[null])` then indexes an array with a null key, which PHP 8.5 deprecates. Any third-party module that registers a category attribute without an input type hits the same path — ElasticSuite is the trigger, not the cause.

## Fix

Short-circuit on null before the array lookup. The ternary already falls through to `$value`, so a null `frontend_input` still yields a null `formElement`, exactly as before:

```php
$meta[$code]['formElement'] = $value !== null && isset($this->formElement[$value])
    ? $this->formElement[$value]
    : $value;
```

## Backward compatibility

None. `isset()` on a null key was already false, so the guard cannot change which branch of the ternary is taken — it only avoids evaluating the offset. Behaviour is identical on PHP < 8.5; on 8.5 the deprecation no longer fires.

## Tests

Includes `DataProviderTest::testGetAttributesMetaWithNullFrontendInput()` from the upstream PR, which asserts `formElement` is null for an attribute with a null `frontend_input` and so fails if the guard is ever removed.

```
$ php vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist \
    app/code/Magento/Catalog/Test/Unit/Model/Category/DataProviderTest.php
Tests: 5, Assertions: 38 — OK
```

## Relationship to #302

#302 proposes this same one-line change, character-for-character. This PR takes it from upstream instead so that we also pick up the regression test, and so we stay aligned with whatever lands in `2.4-develop`.

## Notes on the cherry-pick

The upstream PR has three commits; the two authored changes are carried here and the third, a merge of `2.4-develop` into the contributor's branch, is omitted as it carries no content of its own:

| local | upstream | subject |
|---|---|---|
| `096d162` | `08bed28` | Fix PHP 8.5 deprecation when category attribute has 'frontend_input' defined as 'null'. |
| `f2438d4` | `63d0a5d` | Added unit test |

The resulting net diff was verified to be identical to the upstream PR's net diff.

## Verification notes

Local PHP is 8.4, which does not raise this deprecation, so the failure could not be observed directly here — the trigger path was confirmed by reading the code together with the `eav_attribute` evidence in #302, and the category edit page was not loaded in a browser.

## Upstream status

magento/magento2#40894 is **open, not yet merged** — labelled `Progress: ready for testing` / `Priority: P1`. hostep added the regression test on 2026-08-02 in response to review, and lucafuser approved on 2026-08-03, noting the failing functional and webapi checks are unrelated to the change. Worth re-syncing if the upstream PR moves before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
