### PR TITLE
Fix PHP 8.5 boot failure: KEY_MYSQL_SSL_VERIFY hardcoded as 1014

### DIFF
--- a/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
+++ b/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
@@ -146,13 +146,7 @@ class ConfigOptionsListConstants
     public const KEY_MYSQL_SSL_KEY = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_KEY : \PDO::MYSQL_ATTR_SSL_KEY;
     public const KEY_MYSQL_SSL_CERT = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CERT : \PDO::MYSQL_ATTR_SSL_CERT;
     public const KEY_MYSQL_SSL_CA = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA;
-
-    /**
-     * Constant \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT cannot be used as it was introduced in PHP 7.1.4
-     * and Magento 2 is currently supporting PHP 7.1.3.
-     */
-    public const KEY_MYSQL_SSL_VERIFY = 1014;
-    /**#@-*/
+    public const KEY_MYSQL_SSL_VERIFY = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT : \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
 
     /**
      * Db config key

--- a/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
+++ b/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
@@ -146,7 +146,10 @@ class ConfigOptionsListConstants
     public const KEY_MYSQL_SSL_KEY = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_KEY : \PDO::MYSQL_ATTR_SSL_KEY;
     public const KEY_MYSQL_SSL_CERT = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CERT : \PDO::MYSQL_ATTR_SSL_CERT;
     public const KEY_MYSQL_SSL_CA = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA;
-    public const KEY_MYSQL_SSL_VERIFY = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT : \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
+    public const KEY_MYSQL_SSL_VERIFY = \PHP_VERSION_ID >= 80400
+        ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT
+        : \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
+    /**#@-*/
 
     /**
      * Db config key


### PR DESCRIPTION
Cherry-pick of [magento/magento2#40849](https://github.com/magento/magento2/pull/40849) (authored by shlrkb), plus a follow-up commit fixing two defects the upstream patch introduces.

## Problem

`KEY_MYSQL_SSL_VERIFY` is hardcoded as the literal `1014`, with a comment explaining it as a workaround for PHP 7.1.3 support:

```php
/**
 * Constant \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT cannot be used as it was introduced in PHP 7.1.4
 * and Magento 2 is currently supporting PHP 7.1.3.
 */
public const KEY_MYSQL_SSL_VERIFY = 1014;
```

PHP 8.5 removed `Pdo\Mysql::ATTR_SERVER_PUBLIC_KEY`, which shifts every higher constant value down by one. `1014` therefore stops meaning `ATTR_SSL_VERIFY_SERVER_CERT` and starts meaning `ATTR_LOCAL_INFILE_DIRECTORY`, which expects a path. Passing `false` to it throws a PDOException at boot under `open_basedir`.

This is not a deprecation notice — it is a hard failure on startup.

The shift can be verified from the constant values on PHP 8.4, where the removed constant is still present:

```
ATTR_SERVER_PUBLIC_KEY       1012   <- removed in 8.5
ATTR_SSL_VERIFY_SERVER_CERT  1014   -> becomes 1013
ATTR_LOCAL_INFILE_DIRECTORY  1015   -> becomes 1014
```

## Fix

Resolve the constant at compile time using the same `PHP_VERSION_ID >= 80400` pattern already applied to its three siblings:

```php
public const KEY_MYSQL_SSL_VERIFY = \PHP_VERSION_ID >= 80400
    ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT
    : \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
```

`KEY_MYSQL_SSL_KEY`, `KEY_MYSQL_SSL_CERT` and `KEY_MYSQL_SSL_CA` were already migrated to this form in Mage-OS, with a comment explicitly citing 8.4 deprecation and 8.5 removal. `KEY_MYSQL_SSL_VERIFY` was missed because it was a bare integer rather than a constant reference, so this completes work already started here.

## Follow-up commit

The upstream patch has two defects, fixed in a separate commit so the cherry-pick stays faithful:

1. **It deleted the `/**#@-*\/` that closed the driver-options docblock group.** The removal took out the whole comment block including the group terminator, leaving the `/**#@+` at the top of the section unclosed and its template leaking onto the constants below. Restored, which returns the file to the same open/close marker balance as `main`.
2. **The new line was 149 characters**, over the 120-character limit and flagged by phpcs. Wrapped across three lines.

## Backward compatibility

No signature or API change. On PHP < 8.5 the resolved value is still `1014`, so existing `env.php` files and driver options are unaffected — verified on the PHP 8.4 used here:

```
KEY_MYSQL_SSL_VERIFY = 1014
```

On PHP 8.5 the value becomes `1013`, which is the correct `ATTR_SSL_VERIFY_SERVER_CERT` for that runtime. Consumers are `Setup\Model\ConfigOptionsList`, `Setup\Model\Installer` and `Setup\Model\ConfigOptionsList\DriverOptions`, all of which use the constant symbolically rather than assuming a literal.

Note that an `env.php` written on PHP 8.4 records the numeric key `1014` in `driver_options`; that file is runtime-specific in the same way the sibling SSL constants already are, and this change does not alter that behaviour either way.

## Tests

```
$ php vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist \
    setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsListTest.php
Tests: 13, Assertions: 44 — OK

$ php vendor/bin/phpcs --standard=Magento2 \
    lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
FOUND 0 ERRORS AND 1 WARNING   (the remaining warning is pre-existing trailing
                                whitespace on line 141, untouched here)
```

No new test is added: the constant is resolved at compile time from the running PHP version, so a unit test on this machine (8.4) could only assert the 8.4 branch, which is what the value check above already does.

## Verification notes

Local PHP is 8.4, so the 8.5 boot failure could not be reproduced here. The constant-shift claim was checked against the actual 8.4 constant values shown above, which are exactly self-consistent with the PR's description; the 8.5 side is unverified by direct execution.

## Upstream status

magento/magento2#40849 is **open, not merged** — `Progress: pending review` / `Priority: P1`, opened 2026-06-02, no code review yet. `engcom-Hotel` triggered issue creation from it. Given P1 severity and that this finishes a migration Mage-OS already began, it seemed worth taking ahead of upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
