### PR TITLE
Store non-global compiled DI areas as their diff from global

### DIFF
--- a/lib/internal/Magento/Framework/App/ObjectManager/Environment/Compiled.php
+++ b/lib/internal/Magento/Framework/App/ObjectManager/Environment/Compiled.php
@@ -8,6 +8,7 @@ namespace Magento\Framework\App\ObjectManager\Environment;
 
 use Magento\Framework\App\EnvironmentInterface;
 use Magento\Framework\App\Interception\Cache\CompiledConfig;
+use Magento\Framework\ObjectManager\ConfigLoaderInterface;
 use Magento\Framework\ObjectManager\FactoryInterface;
 use Magento\Framework\App\Area;
 use Magento\Framework\Interception\ObjectManager\ConfigInterface;
@@ -64,7 +65,8 @@ class Compiled extends AbstractEnvironment implements EnvironmentInterface
     {
         if (!$this->config) {
             $this->config = new \Magento\Framework\Interception\ObjectManager\Config\Compiled(
-                $this->getConfigData()
+                $this->getConfigData(),
+                $this->getObjectManagerConfigLoader()
             );
         }
 
@@ -78,7 +80,8 @@ class Compiled extends AbstractEnvironment implements EnvironmentInterface
      */
     protected function getConfigData()
     {
-        return $this->getObjectManagerConfigLoader()->load(Area::AREA_GLOBAL);
+        return $this->getObjectManagerConfigLoader()->load(Area::AREA_GLOBAL)
+            + [ConfigLoaderInterface::AREA_KEY => Area::AREA_GLOBAL];
     }
 
     /**
@@ -103,11 +106,7 @@ class Compiled extends AbstractEnvironment implements EnvironmentInterface
     {
         $objectManager = ObjectManager::getInstance();
 
-        $objectManager->configure(
-            $objectManager
-                ->get(\Magento\Framework\ObjectManager\ConfigLoaderInterface::class)
-                ->load(Area::AREA_GLOBAL)
-        );
+        $objectManager->configure($this->getConfigData());
         $objectManager->get(\Magento\Framework\Config\ScopeInterface::class)
             ->setCurrentScope('global');
         $diConfig->setInterceptionConfig(

--- a/lib/internal/Magento/Framework/ObjectManager/Config/Compiled.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Config/Compiled.php
@@ -7,6 +7,7 @@ namespace Magento\Framework\ObjectManager\Config;
 
 use Magento\Framework\ObjectManager\ConfigInterface;
 use Magento\Framework\ObjectManager\ConfigCacheInterface;
+use Magento\Framework\ObjectManager\ConfigLoaderInterface;
 use Magento\Framework\ObjectManager\LazyTypeAwareInterface;
 use Magento\Framework\ObjectManager\RelationsInterface;
 
@@ -38,10 +39,25 @@ class Compiled implements ConfigInterface, LazyTypeAwareInterface
     private array $lazyTypes = [];
 
     /**
-     * @param array $data
+     * Area whose configuration is currently applied, null when the state matches no single area
+     *
+     * @var string|null
      */
-    public function __construct($data)
+    private $appliedArea;
+
+    /**
+     * @var ConfigLoaderInterface|null
+     */
+    private $configLoader;
+
+    /**
+     * @param array $data
+     * @param ConfigLoaderInterface|null $configLoader
+     */
+    public function __construct($data, ?ConfigLoaderInterface $configLoader = null)
     {
+        $this->configLoader = $configLoader;
+        $this->appliedArea = $data[ConfigLoaderInterface::AREA_KEY] ?? null;
         $this->arguments = isset($data['arguments']) && is_array($data['arguments'])
             ? $data['arguments'] : [];
         $this->virtualTypes = isset($data['instanceTypes']) && is_array($data['instanceTypes'])
@@ -164,6 +180,8 @@ class Compiled implements ConfigInterface, LazyTypeAwareInterface
      */
     public function extend(array $configuration)
     {
+        $configuration = $this->resolveAgainstAppliedArea($configuration);
+
         $this->arguments = isset($configuration['arguments']) && is_array($configuration['arguments'])
             ? array_replace($this->arguments, $configuration['arguments'])
             : $this->arguments;
@@ -176,6 +194,42 @@ class Compiled implements ConfigInterface, LazyTypeAwareInterface
         $this->lazyTypes = isset($configuration['lazyTypes']) && is_array($configuration['lazyTypes'])
             ? array_replace($this->lazyTypes, $configuration['lazyTypes'])
             : $this->lazyTypes;
+    }
+
+    /**
+     * Returns a configuration that is equivalent to the complete one on top of the current state
+     *
+     * @param array $configuration
+     * @return array
+     */
+    private function resolveAgainstAppliedArea(array $configuration)
+    {
+        $base = $configuration[ConfigLoaderInterface::EXTENDS_KEY] ?? null;
+        $resolved = $base !== null && $base !== $this->appliedArea && $this->configLoader !== null
+            ? self::merge($this->configLoader->load($base), $configuration)
+            : $configuration;
+
+        $this->appliedArea = $configuration[ConfigLoaderInterface::AREA_KEY] ?? null;
+
+        return $resolved;
+    }
+
+    /**
+     * Applies a configuration on top of another one, per top-level key of each section
+     *
+     * @param array $base
+     * @param array $configuration
+     * @return array
+     */
+    private static function merge(array $base, array $configuration)
+    {
+        foreach (['arguments', 'instanceTypes', 'preferences', 'lazyTypes'] as $section) {
+            if (isset($configuration[$section]) && is_array($configuration[$section])) {
+                $base[$section] = array_replace($base[$section] ?? [], $configuration[$section]);
+            }
+        }
+
+        return $base;
     }
 
     /**

--- a/lib/internal/Magento/Framework/ObjectManager/Config/Compiled.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Config/Compiled.php
@@ -17,6 +17,11 @@ use Magento\Framework\ObjectManager\RelationsInterface;
 class Compiled implements ConfigInterface, LazyTypeAwareInterface
 {
     /**
+     * Sections of a compiled configuration that are merged per top-level key
+     */
+    public const MERGED_SECTIONS = ['arguments', 'instanceTypes', 'preferences', 'lazyTypes'];
+
+    /**
      * @var array
      */
     private $arguments;
@@ -24,7 +29,7 @@ class Compiled implements ConfigInterface, LazyTypeAwareInterface
     /**
      * @var array
      */
-    private $virtualTypes;
+    private $instanceTypes;
 
     /**
      * @var array
@@ -39,7 +44,8 @@ class Compiled implements ConfigInterface, LazyTypeAwareInterface
     private array $lazyTypes = [];
 
     /**
-     * Area whose configuration is currently applied, null when the state matches no single area
+     * Area whose complete configuration the current state is known to hold. Only the global
+     * bootstrap marks it; any later extension clears it, so the next delta rebuilds from its base.
      *
      * @var string|null
      */
@@ -58,14 +64,9 @@ class Compiled implements ConfigInterface, LazyTypeAwareInterface
     {
         $this->configLoader = $configLoader;
         $this->appliedArea = $data[ConfigLoaderInterface::AREA_KEY] ?? null;
-        $this->arguments = isset($data['arguments']) && is_array($data['arguments'])
-            ? $data['arguments'] : [];
-        $this->virtualTypes = isset($data['instanceTypes']) && is_array($data['instanceTypes'])
-            ? $data['instanceTypes'] : [];
-        $this->preferences = isset($data['preferences']) && is_array($data['preferences'])
-            ? $data['preferences'] : [];
-        $this->lazyTypes = isset($data['lazyTypes']) && is_array($data['lazyTypes'])
-            ? $data['lazyTypes'] : [];
+        foreach (self::MERGED_SECTIONS as $section) {
+            $this->{$section} = isset($data[$section]) && is_array($data[$section]) ? $data[$section] : [];
+        }
     }
 
     /**
@@ -150,8 +151,8 @@ class Compiled implements ConfigInterface, LazyTypeAwareInterface
      */
     public function getInstanceType($instanceName)
     {
-        if (isset($this->virtualTypes[$instanceName])) {
-            return $this->virtualTypes[$instanceName];
+        if (isset($this->instanceTypes[$instanceName])) {
+            return $this->instanceTypes[$instanceName];
         }
         return $instanceName;
     }
@@ -182,18 +183,11 @@ class Compiled implements ConfigInterface, LazyTypeAwareInterface
     {
         $configuration = $this->resolveAgainstAppliedArea($configuration);
 
-        $this->arguments = isset($configuration['arguments']) && is_array($configuration['arguments'])
-            ? array_replace($this->arguments, $configuration['arguments'])
-            : $this->arguments;
-        $this->virtualTypes = isset($configuration['instanceTypes']) && is_array($configuration['instanceTypes'])
-            ? array_replace($this->virtualTypes, $configuration['instanceTypes'])
-            : $this->virtualTypes;
-        $this->preferences = isset($configuration['preferences']) && is_array($configuration['preferences'])
-            ? array_replace($this->preferences, $configuration['preferences'])
-            : $this->preferences;
-        $this->lazyTypes = isset($configuration['lazyTypes']) && is_array($configuration['lazyTypes'])
-            ? array_replace($this->lazyTypes, $configuration['lazyTypes'])
-            : $this->lazyTypes;
+        foreach (self::MERGED_SECTIONS as $section) {
+            if (isset($configuration[$section]) && is_array($configuration[$section])) {
+                $this->{$section} = array_replace($this->{$section}, $configuration[$section]);
+            }
+        }
     }
 
     /**
@@ -223,7 +217,7 @@ class Compiled implements ConfigInterface, LazyTypeAwareInterface
      */
     private static function merge(array $base, array $configuration)
     {
-        foreach (['arguments', 'instanceTypes', 'preferences', 'lazyTypes'] as $section) {
+        foreach (self::MERGED_SECTIONS as $section) {
             if (isset($configuration[$section]) && is_array($configuration[$section])) {
                 $base[$section] = array_replace($base[$section] ?? [], $configuration[$section]);
             }
@@ -239,7 +233,7 @@ class Compiled implements ConfigInterface, LazyTypeAwareInterface
      */
     public function getVirtualTypes()
     {
-        return $this->virtualTypes;
+        return $this->instanceTypes;
     }
 
     /**

--- a/lib/internal/Magento/Framework/ObjectManager/ConfigLoaderInterface.php
+++ b/lib/internal/Magento/Framework/ObjectManager/ConfigLoaderInterface.php
@@ -15,6 +15,16 @@ namespace Magento\Framework\ObjectManager;
 interface ConfigLoaderInterface
 {
     /**
+     * When present, names the area the loaded configuration only holds the differences against
+     */
+    public const EXTENDS_KEY = '_extends';
+
+    /**
+     * When present, names the area the loaded configuration belongs to
+     */
+    public const AREA_KEY = '_area';
+
+    /**
      * Load modules DI configuration
      *
      * @param string $area

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/CompiledTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/CompiledTest.php
@@ -172,7 +172,7 @@ class CompiledTest extends TestCase
     }
 
     /**
-     * Test that $arguments, $virtualTypes and $preferences initializing in construct must be array.
+     * Test that $arguments, $instanceTypes and $preferences initializing in construct must be array.
      *
      * @param $data
      * @param array $expectedResult
@@ -228,7 +228,7 @@ class CompiledTest extends TestCase
     }
 
     /**
-     * Test that $arguments, $virtualTypes and $preferences initializing in extend must be array.
+     * Test that $arguments, $instanceTypes and $preferences initializing in extend must be array.
      *
      * @param $data
      * @param array $expectedResult
@@ -433,5 +433,34 @@ class CompiledTest extends TestCase
         ]);
 
         $this->assertSame('frontendValue', $compiled->getPreference('preference1'));
+    }
+
+    #[DataProvider('mergedSections')]
+    public function testExtendRebuildsEverySectionFromTheBase(string $section): void
+    {
+        $globalConfig = [$section => ['key' => 'globalValue']];
+        $configLoader = $this->createMock(ConfigLoaderInterface::class);
+        $configLoader->method('load')->with('global')->willReturn($globalConfig);
+
+        $compiled = new Compiled(
+            $globalConfig + [ConfigLoaderInterface::AREA_KEY => 'global'],
+            $configLoader
+        );
+
+        $compiled->extend([$section => ['key' => 'mockedValue']]);
+        $compiled->extend([
+            ConfigLoaderInterface::EXTENDS_KEY => 'global',
+            $section => ['key' => 'areaValue'],
+        ]);
+
+        $this->assertSame(
+            ['key' => 'areaValue'],
+            (new \ReflectionClass(Compiled::class))->getProperty($section)->getValue($compiled)
+        );
+    }
+
+    public static function mergedSections(): array
+    {
+        return array_map(static fn (string $section) => [$section], Compiled::MERGED_SECTIONS);
     }
 }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/CompiledTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/CompiledTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\Framework\ObjectManager\Test\Unit\Config;
 
 use Magento\Framework\ObjectManager\Config\Compiled;
+use Magento\Framework\ObjectManager\ConfigLoaderInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -346,5 +347,91 @@ class CompiledTest extends TestCase
         $this->assertFalse($compiled->isNonLazyType('First\\Type'));
         $this->assertFalse($compiled->isNonLazyType('Second\\Type'));
         $this->assertTrue($compiled->isNonLazyType('Other\\Type'));
+    }
+
+    public function testExtendAppliesADeltaOnTopOfTheAreaItExtends(): void
+    {
+        $configLoader = $this->createMock(ConfigLoaderInterface::class);
+        $configLoader->expects($this->never())->method('load');
+
+        $compiled = new Compiled(
+            [
+                'preferences' => ['preference1' => 'globalValue'],
+                ConfigLoaderInterface::AREA_KEY => 'global',
+            ],
+            $configLoader
+        );
+
+        $compiled->extend([
+            ConfigLoaderInterface::EXTENDS_KEY => 'global',
+            'preferences' => ['preference1' => 'frontendValue'],
+        ]);
+
+        $this->assertSame('frontendValue', $compiled->getPreference('preference1'));
+    }
+
+    public function testExtendRebuildsFromTheBaseWhenAnotherAreaIsAlreadyApplied(): void
+    {
+        $globalConfig = ['preferences' => ['preference1' => 'globalValue']];
+        $configLoader = $this->createMock(ConfigLoaderInterface::class);
+        $configLoader->expects($this->once())
+            ->method('load')
+            ->with('global')
+            ->willReturn($globalConfig);
+
+        $compiled = new Compiled(
+            $globalConfig + [ConfigLoaderInterface::AREA_KEY => 'global'],
+            $configLoader
+        );
+
+        $compiled->extend([
+            ConfigLoaderInterface::EXTENDS_KEY => 'global',
+            'preferences' => ['preference1' => 'adminhtmlValue'],
+        ]);
+        $compiled->extend([
+            ConfigLoaderInterface::EXTENDS_KEY => 'global',
+            'preferences' => ['preference2' => 'frontendOnly'],
+        ]);
+
+        $this->assertSame('globalValue', $compiled->getPreference('preference1'));
+        $this->assertSame('frontendOnly', $compiled->getPreference('preference2'));
+    }
+
+    public function testExtendRebuildsFromTheBaseAfterAnArbitraryConfiguration(): void
+    {
+        $globalConfig = ['preferences' => ['preference1' => 'globalValue']];
+        $configLoader = $this->createMock(ConfigLoaderInterface::class);
+        $configLoader->expects($this->once())
+            ->method('load')
+            ->with('global')
+            ->willReturn($globalConfig);
+
+        $compiled = new Compiled(
+            $globalConfig + [ConfigLoaderInterface::AREA_KEY => 'global'],
+            $configLoader
+        );
+
+        $compiled->extend(['preferences' => ['preference1' => 'mockedValue']]);
+        $compiled->extend([
+            ConfigLoaderInterface::EXTENDS_KEY => 'global',
+            'preferences' => [],
+        ]);
+
+        $this->assertSame('globalValue', $compiled->getPreference('preference1'));
+    }
+
+    public function testExtendAppliesADeltaWhenNoLoaderIsAvailable(): void
+    {
+        $compiled = new Compiled([
+            'preferences' => ['preference1' => 'globalValue'],
+            ConfigLoaderInterface::AREA_KEY => 'global',
+        ]);
+
+        $compiled->extend([
+            ConfigLoaderInterface::EXTENDS_KEY => 'global',
+            'preferences' => ['preference1' => 'frontendValue'],
+        ]);
+
+        $this->assertSame('frontendValue', $compiled->getPreference('preference1'));
     }
 }

--- a/setup/src/Magento/Setup/Module/Di/App/Task/Operation/Area.php
+++ b/setup/src/Magento/Setup/Module/Di/App/Task/Operation/Area.php
@@ -7,6 +7,7 @@ namespace Magento\Setup\Module\Di\App\Task\Operation;
 
 use Magento\Setup\Module\Di\App\Task\OperationInterface;
 use Magento\Framework\App;
+use Magento\Framework\ObjectManager\Config\Compiled as CompiledConfig;
 use Magento\Framework\ObjectManager\ConfigLoaderInterface;
 use Magento\Setup\Module\Di\Compiler\Config;
 use Magento\Setup\Module\Di\Definition\Collection as DefinitionsCollection;
@@ -16,11 +17,6 @@ use Magento\Setup\Module\Di\Definition\Collection as DefinitionsCollection;
  */
 class Area implements OperationInterface
 {
-    /**
-     * Sections of the compiled configuration that are merged per top-level key
-     */
-    private const MERGED_SECTIONS = ['arguments', 'preferences', 'instanceTypes', 'lazyTypes'];
-
     /**
      * @var App\AreaList
      */
@@ -129,7 +125,7 @@ class Area implements OperationInterface
         $diff = [ConfigLoaderInterface::EXTENDS_KEY => App\Area::AREA_GLOBAL];
 
         foreach ($config as $section => $values) {
-            if (!is_array($values) || !in_array($section, self::MERGED_SECTIONS, true)) {
+            if (!is_array($values) || !in_array($section, CompiledConfig::MERGED_SECTIONS, true)) {
                 $diff[$section] = $values;
                 continue;
             }

--- a/setup/src/Magento/Setup/Module/Di/App/Task/Operation/Area.php
+++ b/setup/src/Magento/Setup/Module/Di/App/Task/Operation/Area.php
@@ -7,6 +7,7 @@ namespace Magento\Setup\Module\Di\App\Task\Operation;
 
 use Magento\Setup\Module\Di\App\Task\OperationInterface;
 use Magento\Framework\App;
+use Magento\Framework\ObjectManager\ConfigLoaderInterface;
 use Magento\Setup\Module\Di\Compiler\Config;
 use Magento\Setup\Module\Di\Definition\Collection as DefinitionsCollection;
 
@@ -15,6 +16,11 @@ use Magento\Setup\Module\Di\Definition\Collection as DefinitionsCollection;
  */
 class Area implements OperationInterface
 {
+    /**
+     * Sections of the compiled configuration that are merged per top-level key
+     */
+    private const MERGED_SECTIONS = ['arguments', 'preferences', 'instanceTypes', 'lazyTypes'];
+
     /**
      * @var App\AreaList
      */
@@ -91,6 +97,7 @@ class Area implements OperationInterface
         $this->sortDefinitions($definitionsCollection);
 
         $areaCodes = array_merge([App\Area::AREA_GLOBAL], $this->areaList->getCodes());
+        $globalConfig = [];
         foreach ($areaCodes as $areaCode) {
             $config = $this->configReader->generateCachePerScope($definitionsCollection, $areaCode);
             $config = $this->modificationChain->modify($config);
@@ -100,8 +107,44 @@ class Area implements OperationInterface
             ksort($config['preferences']);
             ksort($config['instanceTypes']);
 
+            if ($areaCode === App\Area::AREA_GLOBAL) {
+                $globalConfig = $config;
+            } else {
+                $config = $this->extractDiff($config, $globalConfig);
+            }
+
             $this->configWriter->write($areaCode, $config);
         }
+    }
+
+    /**
+     * Reduces an area configuration to the entries that differ from the global one
+     *
+     * @param array $config
+     * @param array $globalConfig
+     * @return array
+     */
+    private function extractDiff(array $config, array $globalConfig)
+    {
+        $diff = [ConfigLoaderInterface::EXTENDS_KEY => App\Area::AREA_GLOBAL];
+
+        foreach ($config as $section => $values) {
+            if (!is_array($values) || !in_array($section, self::MERGED_SECTIONS, true)) {
+                $diff[$section] = $values;
+                continue;
+            }
+
+            $globalValues = $globalConfig[$section] ?? [];
+            $sectionDiff = [];
+            foreach ($values as $key => $value) {
+                if (!array_key_exists($key, $globalValues) || $globalValues[$key] !== $value) {
+                    $sectionDiff[$key] = $value;
+                }
+            }
+            $diff[$section] = $sectionDiff;
+        }
+
+        return $diff;
     }
 
     /**

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/App/Task/AreaTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/App/Task/AreaTest.php
@@ -10,6 +10,7 @@ namespace Magento\Setup\Test\Unit\Module\Di\App\Task;
 use Magento\Framework\App;
 use Magento\Framework\App\AreaList;
 use Magento\Framework\App\ObjectManager\ConfigWriterInterface;
+use Magento\Framework\ObjectManager\ConfigLoaderInterface;
 use Magento\Setup\Module\Di\App\Task\Operation\Area;
 use Magento\Setup\Module\Di\Compiler\Config;
 use Magento\Setup\Module\Di\Compiler\Config\ModificationChain;
@@ -125,5 +126,74 @@ class AreaTest extends TestCase
             );
 
         $areaOperation->doOperation();
+    }
+
+    public function testDoOperationWritesOnlyTheDifferencesOfNonGlobalAreas()
+    {
+        $path = 'path/to/codebase/';
+
+        $globalConfig = [
+            'arguments' => [
+                'Overridden' => ['b' => 2],
+                'Shared' => ['a' => 1],
+            ],
+            'preferences' => ['SomeInterface' => 'GlobalImplementation'],
+            'instanceTypes' => ['globalVirtual' => 'GlobalType'],
+        ];
+        $frontendConfig = [
+            'arguments' => [
+                'FrontendOnly' => ['c' => 3],
+                'Overridden' => ['b' => 'frontend'],
+                'Shared' => ['a' => 1],
+            ],
+            'preferences' => ['SomeInterface' => 'FrontendImplementation'],
+            'instanceTypes' => ['globalVirtual' => 'GlobalType'],
+        ];
+
+        $areaOperation = new Area(
+            $this->areaListMock,
+            $this->areaInstancesNamesList,
+            $this->configReaderMock,
+            $this->configWriterMock,
+            $this->configChain,
+            [$path]
+        );
+
+        $this->areaListMock->expects($this->once())
+            ->method('getCodes')
+            ->willReturn([App\Area::AREA_FRONTEND]);
+        $this->areaInstancesNamesList->expects($this->once())
+            ->method('getList')
+            ->with($path)
+            ->willReturn([]);
+        $this->configReaderMock->method('generateCachePerScope')
+            ->willReturnCallback(
+                static fn ($definitions, $areaCode) => $areaCode === App\Area::AREA_GLOBAL
+                    ? $globalConfig
+                    : $frontendConfig
+            );
+        $this->configChain->method('modify')->willReturnArgument(0);
+
+        $written = [];
+        $this->configWriterMock->method('write')
+            ->willReturnCallback(function ($areaCode, $config) use (&$written) {
+                $written[$areaCode] = $config;
+            });
+
+        $areaOperation->doOperation();
+
+        $this->assertSame($globalConfig, $written[App\Area::AREA_GLOBAL]);
+        $this->assertSame(
+            [
+                ConfigLoaderInterface::EXTENDS_KEY => App\Area::AREA_GLOBAL,
+                'arguments' => [
+                    'FrontendOnly' => ['c' => 3],
+                    'Overridden' => ['b' => 'frontend'],
+                ],
+                'preferences' => ['SomeInterface' => 'FrontendImplementation'],
+                'instanceTypes' => [],
+            ],
+            $written[App\Area::AREA_FRONTEND]
+        );
     }
 }


### PR DESCRIPTION
### Description (*)

`setup:di:compile` writes a complete DI configuration file per area. On a stock Mage-OS build each of them is ~6.5 MB and the whole set adds up to **44.6 MB**, even though every non-global area is nearly identical to `global`. `crontab.php` turns out to have *zero* differing entries — 6.5 MB that are an exact copy of `global.php`.

This makes each non-global area store only the entries that differ from `global`:

```
area           before      after     differing entries
adminhtml     6555.0 KB   774.5 KB   975 / 17048  (5.72%)
crontab       6502.3 KB     0.2 KB     0 / 16974  (0%)
frontend      6534.6 KB   129.9 KB   173 / 17019  (1.02%)
graphql       6543.9 KB    73.8 KB   110 / 17005  (0.65%)
webapi_rest   6508.6 KB   129.4 KB   104 / 16981  (0.61%)
webapi_soap   6507.2 KB   126.2 KB   100 / 16980  (0.59%)

generated/metadata DI total: 44.6 MB -> 7.6 MB (-83%)
```

#### Why this is equivalent

At runtime an area is always applied on top of `global`, and `ObjectManager\Config\Compiled::extend()` merges with a **top-level `array_replace`** per section. So applying only the entries that differ from `global` leaves the object manager in a state that is *identical* to applying the complete file. This is an equivalence by construction, not an approximation, as long as the diff is computed with a strict (`!==`) comparison on whole top-level values.

Two situations would break that reasoning, and both are handled rather than assumed away:

1. **A second area applied in the same process.** `Config\Compiled` tracks which area its state currently holds. When a delta extends an area other than the one applied, the base is loaded and merged first, restoring entries the previous area had overridden. This does happen in core — see `dev/tests/api-functional/framework/Magento/TestFramework/TestCase/GraphQl/ResolverCacheAbstract.php`, which switches to `graphql` and later restores the previous area.
2. **An arbitrary `configure()` before the area is applied** — e.g. `mockCache()` in `DeployStaticContentCommand`. Any such call clears the tracked area, so the next area is rebuilt from its base.

Files carry an explicit `_extends` marker, so a `generated/` directory produced before this change keeps working untouched, and the interception and plugin-list files that go through the same loader are returned as they are.

#### Behaviour change worth calling out

`ConfigLoader\Compiled` itself is unchanged — `load()` still returns the contents of the compiled file — but for a non-global area that file is now a delta rather than the complete configuration. Every core consumer passes the result straight to `ObjectManagerInterface::configure()`, which resolves it; the two callers that are not areas (`Interception\Config\CacheManager`, `PluginList`) use keys whose files carry no marker and are unaffected; and the DI compiler and `dev:di:info` use the *uncompiled* loader. Third-party code that calls `load()` on an area to **inspect** the configuration rather than to apply it would now receive only the differences.

The alternative — rebuilding the complete configuration inside the loader — was measured: it costs an extra `array_replace` over the full configuration on every request and saves nothing in process memory, so the marker is resolved at the single place that applies it.

#### Measured impact

| | before | after | saving |
|---|---|---|---|
| **OPcache shared memory** (the 7 DI files) | **71.9 MB** | **12.3 MB** | **−59.6 MB** |
| CLI process — `include` **without** OPcache | 59.26 ms / +29.92 MB | 1.10 ms / +0.63 MB | −58 ms, −29 MB |
| Disk | 44.6 MB | 7.6 MB | −37 MB |
| `extend()` per request | 0.664 ms | 0.157 ms | −0.5 ms |
| `include` per request, warm OPcache | ~0 ms | ~0 ms | — |

**Setting expectations honestly: this is not a page-latency optimisation.** On a web request with a warm OPcache the gain is about half a millisecond, which is noise. Constant arrays live in shared memory and cost the worker almost nothing to load — measured, a 100 KB literal array costs 0.5 KB of process memory with OPcache on versus 469.8 KB with it off.

What it does buy is resources and process start-up:

- **OPcache memory.** A compiled file occupies ~1.6× its size in shared memory, so the 44.6 MB on disk were really 71.9 MB of `opcache.memory_consumption`. With PHP's 128 MB default that is over half the pool spent on DI configuration; freeing it removes a common source of evictions, which in turn cause recompilations and real latency spikes.
- **Every CLI process.** `opcache.enable_cli` is off by default, so each `bin/magento` invocation, cron job and queue consumer currently pays ~58 ms and ~30 MB purely to load its area.
- **Disk, images and deploys**, 37 MB smaller.

#### How it was verified

- Unit tests for both the diff and the resolution, plus the full `lib/internal/Magento/Framework` and `setup/src/Magento/Setup` suites: 7545 tests, 23595 assertions, no regressions.
- On a real compiled build, `array_replace(global, delta)` is identical to the complete configuration for all six areas, and both situations above leave the object manager in the same state as today.
- MFTF against a compiled install: `AdminCreateSimpleProductTest` (14 assertions) and `StorefrontCategoryNavigationHighlightingTest` (27 assertions).
- Storefront, admin, REST, GraphQL, `cron:run` and `bin/magento` exercised on a compiled install.

Note: the build used PHP 8.3, where the `LazyTypes` chain returns early, so the `lazyTypes` section of the delta is covered by unit tests but not by a real PHP 8.4 build.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

1. Fixes mage-os/mageos-magento2#203

### Manual testing scenarios (*)

1. Run `bin/magento setup:di:compile` on a stock install. `generated/metadata/global.php` is unchanged; every other area is now a small file starting with `'_extends' => 'global'`.
2. Browse the storefront and the admin, issue a GraphQL query and a REST call — every area must behave as before.
3. Run `bin/magento cron:run` and start a queue consumer.
4. Keep a `generated/` directory compiled *before* this change and boot the application with the new code: those files have no marker and must load exactly as they do today.
5. In a single process, load one area and then another (the GraphQL resolver-cache tests do this): the second area must fully replace the first, as it does today.

### Questions or comments

The reference patch linked in the issue (`monogo-m2-optimize-object-manager`) proved the idea works in production but was not integrable as-is: it computes the diff **at runtime** and writes it back into `generated/metadata/` on the first request (which breaks on read-only filesystems and races between concurrent workers), it merges a recursive diff with `array_replace_recursive` — which is not what `extend()` does and can silently keep stale entries from `global` — and its diff drops any override to a falsy value (`''`, `0`, `false`, `null`, `[]`) through an `if (!empty($value))` check. This implementation moves the whole computation to compile time and mirrors `extend()`'s flat merge exactly.

Worth a follow-up, out of scope here: the compiled plugin-list files (`global|frontend|plugin-list.php` and friends) are also duplicated per scope, but they hold a different structure and their cache key is already cumulative, so they need their own approach.
