### PR TITLE
Port Adobe security patch 249-2026-08-001 (APSB26-92): media gallery ACLs, review_id mass assignment, customer edit form filtering

### DIFF
--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFiles.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFiles.php
@@ -14,6 +14,13 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class DeleteFiles extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images implements HttpPostActionInterface
 {
     /**
+     * Authorization for deleting files
+     *
+     * @see _isAllowed()
+     */
+    public const ADMIN_RESOURCE = 'Magento_MediaGalleryUiApi::delete_assets';
+
+    /**
      * @var \Magento\Framework\Controller\Result\JsonFactory
      */
     protected $resultJsonFactory;

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFolder.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFolder.php
@@ -16,6 +16,13 @@ use Magento\Framework\App\Action\HttpPostActionInterface;
 class DeleteFolder extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images implements HttpPostActionInterface
 {
     /**
+     * Authorization for deleting folder
+     *
+     * @see _isAllowed()
+     */
+    public const ADMIN_RESOURCE = 'Magento_MediaGalleryUiApi::delete_folder';
+
+    /**
      * @var \Magento\Framework\Controller\Result\JsonFactory
      */
     protected $resultJsonFactory;

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/NewFolder.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/NewFolder.php
@@ -14,6 +14,13 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class NewFolder extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images implements HttpPostActionInterface
 {
     /**
+     * Authorization for creating folder
+     *
+     * @see _isAllowed()
+     */
+    public const ADMIN_RESOURCE = 'Magento_MediaGalleryUiApi::create_folder';
+
+    /**
      * @var \Magento\Framework\Controller\Result\JsonFactory
      */
     protected $resultJsonFactory;

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/OnInsert.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/OnInsert.php
@@ -16,6 +16,13 @@ use Magento\Framework\Registry;
 class OnInsert extends Images implements HttpPostActionInterface
 {
     /**
+     * Authorization for inserting files
+     *
+     * @see _isAllowed()
+     */
+    public const ADMIN_RESOURCE = 'Magento_MediaGalleryUiApi::insert_assets';
+
+    /**
      * @var RawFactory
      */
     protected $resultRawFactory;

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/Upload.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/Upload.php
@@ -17,6 +17,13 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class Upload extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images implements HttpPostActionInterface
 {
     /**
+     * Authorization for uploading files
+     *
+     * @see _isAllowed()
+     */
+    public const ADMIN_RESOURCE = 'Magento_MediaGalleryUiApi::upload_assets';
+
+    /**
      * @var \Magento\Framework\Controller\Result\JsonFactory
      */
     protected $resultJsonFactory;

--- a/app/code/Magento/Cms/composer.json
+++ b/app/code/Magento/Cms/composer.json
@@ -10,6 +10,7 @@
         "magento/module-backend": "*",
         "magento/module-catalog": "*",
         "magento/module-email": "*",
+        "magento/module-media-gallery-ui-api": "*",
         "magento/module-media-storage": "*",
         "magento/module-store": "*",
         "magento/module-theme": "*",

--- a/app/code/Magento/Cms/etc/module.xml
+++ b/app/code/Magento/Cms/etc/module.xml
@@ -11,6 +11,7 @@
             <module name="Magento_Store"/>
             <module name="Magento_Theme"/>
             <module name="Magento_Variable"/>
+            <module name="Magento_MediaGalleryUiApi"/>
         </sequence>
     </module>
 </config>

--- a/app/code/Magento/Customer/Controller/Account/Edit.php
+++ b/app/code/Magento/Customer/Controller/Account/Edit.php
@@ -5,11 +5,14 @@
  */
 namespace Magento\Customer\Controller\Account;
 
+use Magento\Customer\Api\CustomerMetadataInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Model\Metadata\FormFactory;
 use Magento\Customer\Model\Session;
 use Magento\Framework\Api\DataObjectHelper;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\View\Result\PageFactory;
 
 class Edit extends \Magento\Customer\Controller\AbstractAccount implements HttpGetActionInterface
@@ -35,23 +38,31 @@ class Edit extends \Magento\Customer\Controller\AbstractAccount implements HttpG
     protected $resultPageFactory;
 
     /**
+     * @var FormFactory
+     */
+    private $formFactory;
+
+    /**
      * @param Context $context
      * @param Session $customerSession
      * @param PageFactory $resultPageFactory
      * @param CustomerRepositoryInterface $customerRepository
      * @param DataObjectHelper $dataObjectHelper
+     * @param FormFactory|null $formFactory
      */
     public function __construct(
         Context $context,
         Session $customerSession,
         PageFactory $resultPageFactory,
         CustomerRepositoryInterface $customerRepository,
-        DataObjectHelper $dataObjectHelper
+        DataObjectHelper $dataObjectHelper,
+        ?FormFactory $formFactory = null
     ) {
         $this->session = $customerSession;
         $this->resultPageFactory = $resultPageFactory;
         $this->customerRepository = $customerRepository;
         $this->dataObjectHelper = $dataObjectHelper;
+        $this->formFactory = $formFactory ?: ObjectManager::getInstance()->get(FormFactory::class);
         parent::__construct($context);
     }
 
@@ -74,11 +85,19 @@ class Edit extends \Magento\Customer\Controller\AbstractAccount implements HttpG
         $customerId = $this->session->getCustomerId();
         $customerDataObject = $this->customerRepository->getById($customerId);
         if (!empty($data)) {
+            $customerForm = $this->formFactory->create(
+                CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER,
+                EditPost::FORM_DATA_EXTRACTOR_CODE
+            );
+            $data = array_intersect_key($data, $customerForm->getAllowedAttributes());
+
             $this->dataObjectHelper->populateWithArray(
                 $customerDataObject,
                 $data,
                 \Magento\Customer\Api\Data\CustomerInterface::class
             );
+
+            $customerDataObject->setId($customerId);
         }
 
         $this->session->setCustomerData($customerDataObject);

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
@@ -37,6 +37,7 @@ class Save extends ProductController implements HttpPostActionInterface
                 $this->messageManager->addErrorMessage(__('The review was removed by another user or does not exist.'));
             } else {
                 try {
+                    unset($data['review_id']);
                     $review->addData($data)->save();
 
                     $arrRatingId = $this->getRequest()->getParam('ratings', []);


### PR DESCRIPTION
### Description

Ports the applicable parts of Adobe's isolated patch **`249-2026-08-001-CE`** (bulletin [APSB26-92](https://helpx.adobe.com/security/products/magento/apsb26-92.html)) into the Mage-OS source tree.

Adobe ships these as `vendor/`-level patches; this PR maps them onto `app/code/` and adds the source-tree-only metadata the isolated patch format cannot carry.

### What is included

**1. `Magento_Cms` — WYSIWYG media browser missing granular ACL checks**

Every `Controller\Adminhtml\Wysiwyg\Images\*` action inherited `ADMIN_RESOURCE = 'Magento_Cms::media_gallery'` from its parent. Any admin role with plain media gallery access could therefore upload, insert, delete files and create/delete folders, regardless of the fine-grained media gallery permissions that already exist in `Magento_MediaGalleryUiApi`.

Each controller now declares its matching resource:

| Controller | ADMIN_RESOURCE |
|---|---|
| `Upload` | `Magento_MediaGalleryUiApi::upload_assets` |
| `OnInsert` | `Magento_MediaGalleryUiApi::insert_assets` |
| `DeleteFiles` | `Magento_MediaGalleryUiApi::delete_assets` |
| `NewFolder` | `Magento_MediaGalleryUiApi::create_folder` |
| `DeleteFolder` | `Magento_MediaGalleryUiApi::delete_folder` |

`Magento_Cms` now sequences `Magento_MediaGalleryUiApi` so those ACL resources are registered before the CMS controllers are resolved.

**2. `Magento_Review` — `review_id` mass assignment**

`Controller\Adminhtml\Product\Save` passed the raw POST body straight into `Review::addData()`. A crafted `review_id` in the request overwrote the identity of the review that had just been loaded and validated, letting a user holding only `Magento_Review::pending` permission modify an arbitrary, already-approved review. `review_id` is now unset before `addData()`.

**3. `Magento_Customer` — unfiltered customer form data on account edit**

`Controller\Account\Edit` repopulated the customer data object from session form data without filtering, so attributes outside the `customer_account_edit` form — including a foreign entity id — could be injected into the rendered form. Data is now intersected with the form's allowed attributes and the customer id is forced back to the session customer.

### What is deliberately not included

- **`lib/web/underscore.js`** — the patch bumps Underscore 1.13.7 → 1.13.8 (CVE-2026-27601, stack overflow in `_.isEqual`). Mage-OS already carries 1.13.8 with the trampolined `isEqual`, applied in `bdbeaab98f8`. No change needed.
- **`vendor/bin/patch-status`** — a build artifact of Adobe's patch tooling with no counterpart in this repository.

### Additions beyond the isolated patch

- `app/code/Magento/Cms/composer.json` gains `magento/module-media-gallery-ui-api: *`. Isolated patches cannot modify composer metadata, but in the source tree the new `module.xml` sequence and the `Magento_MediaGalleryUiApi::` ACL identifiers constitute a hard module dependency that the static `DependencyTest` requires to be declared. `Magento_MediaGalleryUiApi` only *suggests* `magento/module-cms`, so this introduces no composer cycle.

### Manual testing scenarios

1. Create an admin role granted **Content > Media Gallery** but with the individual *Upload assets* / *Delete assets* / *Create folder* / *Delete folder* / *Insert assets* resources unchecked. Open the WYSIWYG media browser and confirm each of those operations is now denied.
2. Grant the individual resources and confirm all operations work as before.
3. As an admin with only **Reviews > Pending Reviews**, submit a review save with a `review_id` pointing at an approved review; confirm the approved review is untouched.
4. Submit an invalid customer account edit so form data is stored in the session, then reload `customer/account/edit`; confirm the form repopulates only with `customer_account_edit` attributes and the session customer's id.

### Checklist

- [x] Ported from an upstream Adobe security patch
- [x] `php -l` clean on all changed files
- [x] Existing `Magento\Cms\Controller\Adminhtml\Wysiwyg\Images` integration tests instantiate the controllers directly rather than dispatching through ACL, so they are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFUinA5RqzxPs2nN9P1V6g
