### PR TITLE
Fix MockCreationTrait::createPartialMockWithReflection() fatal error on interfaces with more abstract methods than requested

### DIFF
--- a/lib/internal/Magento/Framework/TestFramework/Unit/Helper/MockCreationTrait.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Helper/MockCreationTrait.php
@@ -43,7 +43,17 @@ trait MockCreationTrait
 
         $builderReflection = new ReflectionClass($mockBuilder);
         $methodsProperty = $builderReflection->getProperty('methods');
-        $methodsProperty->setValue($mockBuilder, $methods);
+
+        $targetReflection = new ReflectionClass($className);
+        $abstractMethods = array_map(
+            static fn (\ReflectionMethod $method): string => $method->getName(),
+            array_filter(
+                $targetReflection->getMethods(),
+                static fn (\ReflectionMethod $method): bool => $targetReflection->isInterface() || $method->isAbstract()
+            )
+        );
+
+        $methodsProperty->setValue($mockBuilder, array_values(array_unique(array_merge($methods, $abstractMethods))));
 
         if (empty($constructorArgs)) {
             $mockBuilder->disableOriginalConstructor();

--- a/lib/internal/Magento/Framework/TestFramework/Unit/Helper/MockCreationTrait.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Helper/MockCreationTrait.php
@@ -44,13 +44,9 @@ trait MockCreationTrait
         $builderReflection = new ReflectionClass($mockBuilder);
         $methodsProperty = $builderReflection->getProperty('methods');
 
-        $targetReflection = new ReflectionClass($className);
         $abstractMethods = array_map(
             static fn (\ReflectionMethod $method): string => $method->getName(),
-            array_filter(
-                $targetReflection->getMethods(),
-                static fn (\ReflectionMethod $method): bool => $targetReflection->isInterface() || $method->isAbstract()
-            )
+            (new ReflectionClass($className))->getMethods(\ReflectionMethod::IS_ABSTRACT)
         );
 
         $methodsProperty->setValue($mockBuilder, array_values(array_unique(array_merge($methods, $abstractMethods))));


### PR DESCRIPTION
Fixes #331

## Summary

`createPartialMockWithReflection()` builds a mock via reflection into PHPUnit's private `MockBuilder::$methods` property, setting it to exactly the caller-supplied `$methods` array. This bypasses PHPUnit's normal `onlyMethods()`/`addMethods()` semantics — the generated mock class only gets bodies for the methods literally listed, but the class still `implements` the full target interface, so PHP's own class-completeness check fatally errors on any interface method left undeclared.

This is invisible as long as the target interface has exactly the methods a test passes in. It breaks the moment the interface — especially a Magento-generated "extension interface" assembled at compile time from every installed module's `extension_attributes.xml` — grows beyond what the test originally assumed. `Magento\Bundle\Test\Unit\Model\ProductOptionProcessorTest` passes only Bundle's own two methods (`getBundleOptions`/`setBundleOptions`), correct in isolation, but fatal on any installation where Catalog/Downloadable/ConfigurableProduct also extend the same shared interface — i.e. most real installations with those modules enabled.

## Fix

Union the caller-supplied `$methods` with every abstract method reflection finds on the target class/interface, so the generated mock always satisfies the full interface while callers can still configure just the methods they listed via `->method()`/`expects()`.

## Test plan

- `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist` no longer fatally crashes on `Magento\Bundle\Test\Unit\Model\ProductOptionProcessorTest` on an installation where `Magento\Catalog\Api\Data\ProductOptionExtensionInterface` compiles to 8 methods (Catalog + Bundle + Downloadable + ConfigurableProduct extension attributes).
- Behavior for callers where the target has exactly the requested methods is unchanged (union is a no-op).