### PR TITLE
Apply Adobe VULN-39341 hotfix (StyleSmuggler)

### DIFF
--- a/app/code/Magento/Backend/Model/Widget/Grid/Row/UrlGeneratorFactory.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Row/UrlGeneratorFactory.php
@@ -36,11 +36,11 @@ class UrlGeneratorFactory
      */
     public function createUrlGenerator($generatorClassName, array $arguments = [])
     {
-        $rowUrlGenerator = $this->_objectManager->create($generatorClassName, $arguments);
-        if (false === $rowUrlGenerator instanceof \Magento\Backend\Model\Widget\Grid\Row\GeneratorInterface) {
+        // Validate the type BEFORE instantiation.
+        if (!is_a($generatorClassName, \Magento\Backend\Model\Widget\Grid\Row\GeneratorInterface::class, true)) {
             throw new \InvalidArgumentException('Passed wrong parameters');
         }
 
-        return $rowUrlGenerator;
+        return $this->_objectManager->create($generatorClassName, $arguments);
     }
 }

--- a/app/code/Magento/Email/Block/Adminhtml/Template/Preview.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template/Preview.php
@@ -26,6 +26,11 @@ use Magento\Store\Model\Store;
 class Preview extends Widget
 {
     /**
+     * @var string
+     */
+    private const ADMIN_RESOURCE = 'Magento_Email::template';
+
+    /**
      * @var MaliciousCode
      */
     protected $_maliciousCode;
@@ -65,6 +70,10 @@ class Preview extends Widget
      */
     protected function _toHtml()
     {
+        if (!$this->_authorization->isAllowed(self::ADMIN_RESOURCE)) {
+            return '';
+        }
+
         $request = $this->getRequest();
 
         $storeId = $this->getAnyStoreView()->getId();

--- a/app/code/Magento/Email/Model/AbstractTemplate.php
+++ b/app/code/Magento/Email/Model/AbstractTemplate.php
@@ -762,6 +762,32 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
     }
 
     /**
+     * Set template text
+     *
+     * Rejects non-string input
+     *
+     * @param mixed $value
+     * @return $this
+     */
+    public function setTemplateText($value)
+    {
+        return $this->setData('template_text', is_string($value) ? $value : '');
+    }
+
+    /**
+     * Set template styles
+     *
+     * Rejects non-string input
+     *
+     * @param mixed $value
+     * @return $this
+     */
+    public function setTemplateStyles($value)
+    {
+        return $this->setData('template_styles', is_string($value) ? $value : '');
+    }
+
+    /**
      * Validate template code
      *
      * @throws ValidationException

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Queue/Preview.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Queue/Preview.php
@@ -16,6 +16,11 @@ class Preview extends \Magento\Newsletter\Block\Adminhtml\Template\Preview
     /**
      * @var string
      */
+    protected const ADMIN_RESOURCE = 'Magento_Newsletter::queue';
+
+    /**
+     * @var string
+     */
     protected $profilerName = "newsletter_queue_proccessing";
 
     /**

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Template/Preview.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Template/Preview.php
@@ -25,6 +25,11 @@ use Magento\Newsletter\Model\SubscriberFactory;
 class Preview extends Widget
 {
     /**
+     * @var string
+     */
+    protected const ADMIN_RESOURCE = 'Magento_Newsletter::template';
+
+    /**
      * Name for profiler
      *
      * @var string
@@ -74,6 +79,10 @@ class Preview extends Widget
      */
     protected function _toHtml()
     {
+        if (!$this->_authorization->isAllowed(static::ADMIN_RESOURCE)) {
+            return '';
+        }
+
         /* @var $template \Magento\Newsletter\Model\Template */
         $template = $this->_templateFactory->create();
 

--- a/lib/internal/Magento/Framework/View/Element/BlockFactory.php
+++ b/lib/internal/Magento/Framework/View/Element/BlockFactory.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Framework\View\Element;
 
+use Magento\Framework\ObjectManager\ConfigInterface;
 use Magento\Framework\ObjectManagerInterface;
 
 /**
@@ -21,13 +22,23 @@ class BlockFactory
     protected $objectManager;
 
     /**
+     * @var ConfigInterface
+     */
+    private $objectManagerConfig;
+
+    /**
      * Constructor
      *
      * @param ObjectManagerInterface $objectManager
+     * @param ConfigInterface|null $objectManagerConfig
      */
-    public function __construct(ObjectManagerInterface $objectManager)
-    {
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        ?ConfigInterface $objectManagerConfig = null
+    ) {
         $this->objectManager = $objectManager;
+        $this->objectManagerConfig = $objectManagerConfig ?:
+            \Magento\Framework\App\ObjectManager::getInstance()->get(ConfigInterface::class);
     }
 
     /**
@@ -45,10 +56,13 @@ class BlockFactory
     public function createBlock($blockName, array $arguments = [])
     {
         $blockName = ltrim($blockName, '\\');
-        $block = $this->objectManager->create($blockName, $arguments);
-        if (!$block instanceof BlockInterface) {
+        $resolvedType = $this->objectManagerConfig->getInstanceType(
+            $this->objectManagerConfig->getPreference($blockName)
+        );
+        if (!is_a($resolvedType, BlockInterface::class, true)) {
             throw new \LogicException($blockName . ' does not implement BlockInterface');
         }
+        $block = $this->objectManager->create($blockName, $arguments);
         if ($block instanceof Template) {
             $block->setTemplateContext($block);
         }

--- a/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
@@ -277,7 +277,7 @@ class Block implements Layout\GeneratorInterface
         if ($block && is_string($block)) {
             try {
                 $block = $this->blockFactory->createBlock($block, $arguments);
-            } catch (\ReflectionException $e) {
+            } catch (\ReflectionException | \LogicException $e) {
                 $this->logger->critical($e->getMessage());
             }
         }

--- a/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
@@ -46,6 +46,11 @@ class ErrorProcessor
     public const DATA_FORMAT_XML = 'xml';
 
     /**
+     * @var string
+     */
+    private const REPORT_EXECUTION_GUARD = '<?php exit; ?>';
+
+    /**
      * @var \Magento\Framework\Json\Encoder $encoder
      */
     protected $encoder;
@@ -443,7 +448,13 @@ class ErrorProcessor
     {
         $this->directoryWrite->create('report/api');
         $reportId = abs((int)(microtime(true) * random_int(100, 1000)));
-        $this->directoryWrite->writeFile('report/api/' . $reportId, $this->serializer->serialize($reportData));
+        if (is_string($reportData)) {
+            $reportData = str_replace('<?', '< ?', $reportData);
+        }
+        $this->directoryWrite->writeFile(
+            'report/api/' . $reportId,
+            self::REPORT_EXECUTION_GUARD . PHP_EOL . $this->serializer->serialize($reportData)
+        );
         return $reportId;
     }
 }

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -29,6 +29,11 @@ class Processor
     public const NUMBER_SYMBOLS_IN_SUBDIR_NAME = 2;
 
     /**
+     * @var string
+     */
+    private const REPORT_EXECUTION_GUARD = '<?php exit; ?>';
+
+    /**
      * Page title
      *
      * @var string
@@ -530,7 +535,11 @@ class Processor
         }
         $this->_setReportData($reportData);
 
-        @file_put_contents($this->_reportFile, $this->serializer->serialize($reportData). PHP_EOL);
+        $reportData = $this->sanitizeReportData($reportData);
+        @file_put_contents(
+            $this->_reportFile,
+            self::REPORT_EXECUTION_GUARD . PHP_EOL . $this->serializer->serialize($reportData) . PHP_EOL
+        );
 
         if (isset($reportData['skin']) && self::DEFAULT_SKIN != $reportData['skin']) {
             $this->_setSkin($reportData['skin']);
@@ -538,6 +547,38 @@ class Processor
         $this->_setReportUrl();
 
         return $this->reportUrl;
+    }
+
+    /**
+     * Neutralize PHP open tags inside report values.
+     *
+     * @param array $data
+     * @return array
+     */
+    private function sanitizeReportData(array $data): array
+    {
+        array_walk_recursive($data, static function (&$value) {
+            if (is_string($value)) {
+                $value = str_replace('<?', '< ?', $value);
+            }
+        });
+        return $data;
+    }
+
+    /**
+     * Read a report file, stripping the execution-guard prefix when present.
+     *
+     * @param string $reportFile
+     * @return string
+     */
+    private function readReportFile(string $reportFile): string
+    {
+        $contents = (string)file_get_contents($reportFile);
+        $guard = self::REPORT_EXECUTION_GUARD;
+        if (strncmp($contents, $guard, strlen($guard)) === 0) {
+            $contents = ltrim(substr($contents, strlen($guard)), "\r\n");
+        }
+        return $contents;
     }
 
     /**
@@ -558,7 +599,9 @@ class Processor
             }
             $this->reportId = $reportId;
             $this->_reportFile = $reportFile;
-            $this->_setReportData($this->serializer->unserialize(file_get_contents($this->_reportFile)));
+            $this->_setReportData(
+                $this->serializer->unserialize($this->readReportFile($this->_reportFile))
+            );
         } catch (\RuntimeException $e) {
             $this->redirectToBaseUrl();
         }


### PR DESCRIPTION
### Description

Ports Adobe's official `VULN-39341_249` hotfix (StyleSmuggler, per [Sansec's research](https://sansec.io/research/stylesmuggler)) to `main`:

- **Backend grid row UrlGeneratorFactory**: validates the generator class implements `GeneratorInterface` *before* instantiation, so gadget constructor arguments are never resolved.
- **Email and Newsletter admin Preview blocks**: `_toHtml()` requires the matching ACL resource (`Magento_Email::template`, `Magento_Newsletter::template`, `Magento_Newsletter::queue`) before rendering request-driven previews.
- **Email AbstractTemplate**: string-coercing `setTemplateText()` / `setTemplateStyles()` so structured data cannot reach the template filter.
- **BlockFactory**: resolves the DI preference and validates the type against `BlockInterface` before instantiation; `Layout\Generator\Block` catches the resulting `LogicException`.
- **Webapi ErrorProcessor and `pub/errors/processor.php`**: error reports are prefixed with a `<?php exit; ?>` execution guard and PHP open tags in report data are neutralized; the guard is stripped when a report is read back.

All hunks are verbatim from Adobe's patch except the Email Preview block, which is adapted to this branch's short-import form of the file (Adobe's context targets the older FQCN form still present on 2.4-develop).

### Notes

- Adobe ships no test updates; 7 pre-existing unit tests fail against these changes (the three Preview test classes hit `isAllowed() on null` because their mocks don't provide authorization, and `BlockFactoryTest` doesn't mock the new object-manager config dependency). They need updating in a follow-up unless upstream's own 2.4.9-p2 test changes get imported.
- A follow-up PR stacks additional defense-in-depth hardening on this branch.

### Manual testing scenarios

1. Admin > Marketing > Email Templates > preview a template: renders as before for an admin with the resource; renders empty without it.
2. Trigger a Web API fatal error: the generated `var/report/api/*` file starts with `<?php exit; ?>` and is unreadable via direct include.

https://claude.ai/code/session_01AFRouZsJCcn8oc1egJ6YSG