### PR TITLE
StyleSmuggler defense-in-depth on top of VULN-39341

### DIFF
--- a/app/code/Magento/Backend/Model/Widget/Grid/Row/UrlGeneratorFactory.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Row/UrlGeneratorFactory.php
@@ -36,11 +36,11 @@ class UrlGeneratorFactory
      */
     public function createUrlGenerator($generatorClassName, array $arguments = [])
     {
-        $rowUrlGenerator = $this->_objectManager->create($generatorClassName, $arguments);
-        if (false === $rowUrlGenerator instanceof \Magento\Backend\Model\Widget\Grid\Row\GeneratorInterface) {
+        // Validate the type BEFORE instantiation.
+        if (!is_a($generatorClassName, \Magento\Backend\Model\Widget\Grid\Row\GeneratorInterface::class, true)) {
             throw new \InvalidArgumentException('Passed wrong parameters');
         }
 
-        return $rowUrlGenerator;
+        return $this->_objectManager->create($generatorClassName, $arguments);
     }
 }

--- a/app/code/Magento/Email/Block/Adminhtml/Template/Preview.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template/Preview.php
@@ -26,6 +26,11 @@ use Magento\Store\Model\Store;
 class Preview extends Widget
 {
     /**
+     * @var string
+     */
+    private const ADMIN_RESOURCE = 'Magento_Email::template';
+
+    /**
      * @var MaliciousCode
      */
     protected $_maliciousCode;
@@ -65,6 +70,10 @@ class Preview extends Widget
      */
     protected function _toHtml()
     {
+        if (!$this->_authorization->isAllowed(self::ADMIN_RESOURCE)) {
+            return '';
+        }
+
         $request = $this->getRequest();
 
         $storeId = $this->getAnyStoreView()->getId();

--- a/app/code/Magento/Email/Model/AbstractTemplate.php
+++ b/app/code/Magento/Email/Model/AbstractTemplate.php
@@ -762,6 +762,32 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
     }
 
     /**
+     * Set template text
+     *
+     * Rejects non-string input
+     *
+     * @param mixed $value
+     * @return $this
+     */
+    public function setTemplateText($value)
+    {
+        return $this->setData('template_text', is_string($value) ? $value : '');
+    }
+
+    /**
+     * Set template styles
+     *
+     * Rejects non-string input
+     *
+     * @param mixed $value
+     * @return $this
+     */
+    public function setTemplateStyles($value)
+    {
+        return $this->setData('template_styles', is_string($value) ? $value : '');
+    }
+
+    /**
      * Validate template code
      *
      * @throws ValidationException

--- a/app/code/Magento/Email/Model/Template/Filter.php
+++ b/app/code/Magento/Email/Model/Template/Filter.php
@@ -412,6 +412,13 @@ class Filter extends Template
         $block = null;
 
         if (isset($blockParameters['class'])) {
+            if ($this->isRestrictedBlockClass((string)$blockParameters['class'])) {
+                $this->_logger->warning(
+                    'Refused to instantiate a restricted block class from a template directive.',
+                    ['class' => (string)$blockParameters['class']]
+                );
+                return '';
+            }
             $block = $this->_layout->createBlock($blockParameters['class'], null, ['data' => $blockParameters]);
         } elseif (isset($blockParameters['id'])) {
             $block = $this->_layout->createBlock(Block::class);
@@ -421,6 +428,15 @@ class Filter extends Template
         }
 
         if (!$block) {
+            return '';
+        }
+
+        // Re-check the class actually instantiated.
+        if ($this->isRestrictedBlockClass(get_class($block))) {
+            $this->_logger->warning(
+                'Refused to render a restricted block class resolved from a template directive.',
+                ['class' => get_class($block), 'requested' => (string)($blockParameters['class'] ?? '')]
+            );
             return '';
         }
 
@@ -447,6 +463,32 @@ class Filter extends Template
             $method = 'toHtml';
         }
         return $block->{$method}();
+    }
+
+    /**
+     * Whether a class is off limits to the {{block}} directive.
+     *
+     * @param string $class
+     * @return bool
+     */
+    private function isRestrictedBlockClass(string $class): bool
+    {
+        // Canonicalize separator spelling before matching.
+        $normalized = str_replace('/', '\\', trim($class));
+        while (strpos($normalized, '\\\\') !== false) {
+            $normalized = str_replace('\\\\', '\\', $normalized);
+        }
+        $normalized = ltrim($normalized, '\\');
+        if ($normalized === '') {
+            return false;
+        }
+        if (stripos($normalized, '\\Block\\Adminhtml\\') !== false) {
+            return true;
+        }
+        if (stripos($normalized, 'Magento\\Backend\\Block\\') === 0) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/app/code/Magento/Email/Model/Template/Filter.php
+++ b/app/code/Magento/Email/Model/Template/Filter.php
@@ -420,14 +420,16 @@ class Filter extends Template
         $blockParameters = $this->getParameters($construction[2]);
 
         // Blocks may only opt into the frontend area; drop any other area override.
-        if (isset($blockParameters['area'])
-            && strcasecmp((string)$blockParameters['area'], Area::AREA_FRONTEND) !== 0
-        ) {
-            $this->_logger->warning(
-                'Ignored a non-frontend area override on a template block directive.',
-                ['area' => (string)$blockParameters['area']]
-            );
-            unset($blockParameters['area']);
+        if (isset($blockParameters['area'])) {
+            $blockParameters['area'] = trim((string)$blockParameters['area']);
+
+            if (strcasecmp($blockParameters['area'], Area::AREA_FRONTEND) !== 0) {
+                $this->_logger->warning(
+                    'Ignored a non-frontend area override on a template block directive.',
+                    ['area' => $blockParameters['area']]
+                );
+                unset($blockParameters['area']);
+            }
         }
 
         $block = null;
@@ -495,9 +497,9 @@ class Filter extends Template
     public function layoutDirective($construction)
     {
         $this->_directiveParams = $this->getParameters($construction[2]);
-        if (!isset($this->_directiveParams['area'])) {
-            $this->_directiveParams['area'] = Area::AREA_FRONTEND;
-        }
+        // Surrounding whitespace must not let an area slip past the comparison below.
+        $area = trim((string)($this->_directiveParams['area'] ?? ''));
+        $this->_directiveParams['area'] = $area !== '' ? $area : Area::AREA_FRONTEND;
 
         // Adminhtml layout handles are off limits to filtered templates.
         if (strcasecmp((string)$this->_directiveParams['area'], Area::AREA_ADMINHTML) === 0) {

--- a/app/code/Magento/Email/Model/Template/Filter.php
+++ b/app/code/Magento/Email/Model/Template/Filter.php
@@ -10,6 +10,7 @@ namespace Magento\Email\Model\Template;
 use Exception;
 use Magento\Backend\Model\Url as BackendModelUrl;
 use Magento\Cms\Block\Block;
+use Magento\Email\Model\Template\Filter\BlockDirectivePolicy;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
@@ -198,6 +199,11 @@ class Filter extends Template
     private $inlineTranslationState;
 
     /**
+     * @var BlockDirectivePolicy
+     */
+    private $blockDirectivePolicy;
+
+    /**
      * Filter constructor.
      * @param StringUtils $string
      * @param LoggerInterface $logger
@@ -219,6 +225,7 @@ class Filter extends Template
      * @param array $directiveProcessors
      * @param StoreInformation|null $storeInformation
      * @param StateInterface|null $inlineTranslationState
+     * @param BlockDirectivePolicy|null $blockDirectivePolicy
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -241,7 +248,8 @@ class Filter extends Template
         $variables = [],
         array $directiveProcessors = [],
         ?StoreInformation $storeInformation = null,
-        ?StateInterface $inlineTranslationState = null
+        ?StateInterface $inlineTranslationState = null,
+        ?BlockDirectivePolicy $blockDirectivePolicy = null
     ) {
         $this->_escaper = $escaper;
         $this->_assetRepo = $assetRepo;
@@ -262,6 +270,8 @@ class Filter extends Template
             ObjectManager::getInstance()->get(StoreInformation::class);
         $this->inlineTranslationState = $inlineTranslationState ?:
             ObjectManager::getInstance()->get(StateInterface::class);
+        $this->blockDirectivePolicy = $blockDirectivePolicy ?:
+            ObjectManager::getInstance()->get(BlockDirectivePolicy::class);
         parent::__construct($string, $variables, $directiveProcessors, $variableResolver);
     }
 
@@ -421,7 +431,7 @@ class Filter extends Template
         $block = null;
 
         if (isset($blockParameters['class'])) {
-            if ($this->isRestrictedBlockClass((string)$blockParameters['class'])) {
+            if ($this->blockDirectivePolicy->isRestricted((string)$blockParameters['class'])) {
                 $this->_logger->warning(
                     'Refused to instantiate a restricted block class from a template directive.',
                     ['class' => (string)$blockParameters['class']]
@@ -441,7 +451,7 @@ class Filter extends Template
         }
 
         // Re-check the class actually instantiated.
-        if ($this->isRestrictedBlockClass(get_class($block))) {
+        if ($this->blockDirectivePolicy->isRestricted(get_class($block))) {
             $this->_logger->warning(
                 'Refused to render a restricted block class resolved from a template directive.',
                 ['class' => get_class($block), 'requested' => (string)($blockParameters['class'] ?? '')]
@@ -472,37 +482,6 @@ class Filter extends Template
             $method = 'toHtml';
         }
         return $block->{$method}();
-    }
-
-    /**
-     * Whether a class is off limits to the {{block}} directive.
-     *
-     * @param string $class
-     * @return bool
-     */
-    private function isRestrictedBlockClass(string $class): bool
-    {
-        // Canonicalize separator spelling before matching.
-        $normalized = str_replace('/', '\\', trim($class));
-        while (strpos($normalized, '\\\\') !== false) {
-            $normalized = str_replace('\\\\', '\\', $normalized);
-        }
-        $normalized = ltrim($normalized, '\\');
-        if ($normalized === '') {
-            return false;
-        }
-        if (stripos($normalized, '\\Block\\Adminhtml\\') !== false
-            || stripos($normalized, '\\Block\\Backend\\') !== false
-            || stripos($normalized, '\\Block\\System\\Config\\') !== false
-        ) {
-            return true;
-        }
-        if (stripos($normalized, 'Magento\\Backend\\Block\\') === 0
-            || stripos($normalized, 'Magento\\User\\Block\\') === 0
-        ) {
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/app/code/Magento/Email/Model/Template/Filter.php
+++ b/app/code/Magento/Email/Model/Template/Filter.php
@@ -409,6 +409,15 @@ class Filter extends Template
         $skipParams = ['class', 'id', 'output'];
         $blockParameters = $this->getParameters($construction[2]);
 
+        // Blocks render in the current area; drop any area override.
+        if (isset($blockParameters['area'])) {
+            $this->_logger->warning(
+                'Ignored an area override on a template block directive.',
+                ['area' => (string)$blockParameters['area']]
+            );
+            unset($blockParameters['area']);
+        }
+
         $block = null;
 
         if (isset($blockParameters['class'])) {
@@ -482,10 +491,15 @@ class Filter extends Template
         if ($normalized === '') {
             return false;
         }
-        if (stripos($normalized, '\\Block\\Adminhtml\\') !== false) {
+        if (stripos($normalized, '\\Block\\Adminhtml\\') !== false
+            || stripos($normalized, '\\Block\\Backend\\') !== false
+            || stripos($normalized, '\\Block\\System\\Config\\') !== false
+        ) {
             return true;
         }
-        if (stripos($normalized, 'Magento\\Backend\\Block\\') === 0) {
+        if (stripos($normalized, 'Magento\\Backend\\Block\\') === 0
+            || stripos($normalized, 'Magento\\User\\Block\\') === 0
+        ) {
             return true;
         }
         return false;
@@ -503,6 +517,16 @@ class Filter extends Template
         if (!isset($this->_directiveParams['area'])) {
             $this->_directiveParams['area'] = Area::AREA_FRONTEND;
         }
+
+        // Adminhtml layout handles are off limits to filtered templates.
+        if (strcasecmp((string)$this->_directiveParams['area'], Area::AREA_ADMINHTML) === 0) {
+            $this->_logger->warning(
+                'Refused to render an adminhtml layout handle from a template directive.',
+                ['handle' => (string)($this->_directiveParams['handle'] ?? '')]
+            );
+            return '';
+        }
+
         if ($this->_directiveParams['area'] != $this->_appState->getAreaCode()) {
             return $this->_appState->emulateAreaCode(
                 $this->_directiveParams['area'],

--- a/app/code/Magento/Email/Model/Template/Filter.php
+++ b/app/code/Magento/Email/Model/Template/Filter.php
@@ -1046,6 +1046,7 @@ class Filter extends Template
         // If this template is a child of another template, skip processing so that the parent template will process
         // this directive. This is important as CSS inlining must operate on the entire HTML document.
         if ($this->isChildTemplate()) {
+            $this->deferToParent($construction[0]);
             return $construction[0];
         }
 

--- a/app/code/Magento/Email/Model/Template/Filter.php
+++ b/app/code/Magento/Email/Model/Template/Filter.php
@@ -419,10 +419,12 @@ class Filter extends Template
         $skipParams = ['class', 'id', 'output'];
         $blockParameters = $this->getParameters($construction[2]);
 
-        // Blocks render in the current area; drop any area override.
-        if (isset($blockParameters['area'])) {
+        // Blocks may only opt into the frontend area; drop any other area override.
+        if (isset($blockParameters['area'])
+            && strcasecmp((string)$blockParameters['area'], Area::AREA_FRONTEND) !== 0
+        ) {
             $this->_logger->warning(
-                'Ignored an area override on a template block directive.',
+                'Ignored a non-frontend area override on a template block directive.',
                 ['area' => (string)$blockParameters['area']]
             );
             unset($blockParameters['area']);

--- a/app/code/Magento/Email/Model/Template/Filter/BlockDirectivePolicy.php
+++ b/app/code/Magento/Email/Model/Template/Filter/BlockDirectivePolicy.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright © Mage-OS. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Email\Model\Template\Filter;
+
+/**
+ * Decides which block classes the {{block}} template directive may instantiate.
+ *
+ * Restriction patterns and exact-class exemptions are supplied through di.xml; a pattern
+ * starting with "^" matches the beginning of the class name, any other pattern matches
+ * anywhere in it. All matching is case-insensitive against a canonicalized class name.
+ */
+class BlockDirectivePolicy
+{
+    /**
+     * @var string[]
+     */
+    private $restrictedPatterns;
+
+    /**
+     * @var string[]
+     */
+    private $allowedClasses;
+
+    /**
+     * @param string[] $restrictedPatterns
+     * @param string[] $allowedClasses
+     */
+    public function __construct(
+        array $restrictedPatterns = [],
+        array $allowedClasses = []
+    ) {
+        $this->restrictedPatterns = $restrictedPatterns;
+        $this->allowedClasses = $allowedClasses;
+    }
+
+    /**
+     * Whether a class is off limits to the {{block}} directive.
+     *
+     * @param string $class
+     * @return bool
+     */
+    public function isRestricted(string $class): bool
+    {
+        $normalized = $this->normalize($class);
+
+        if ($normalized === '') {
+            return false;
+        }
+
+        foreach ($this->allowedClasses as $allowed) {
+            if (strcasecmp($normalized, $this->normalize((string)$allowed)) === 0) {
+                return false;
+            }
+        }
+
+        foreach ($this->restrictedPatterns as $pattern) {
+            $pattern = (string)$pattern;
+
+            if ($pattern === '' || $pattern === '^') {
+                continue;
+            }
+
+            if (strncmp($pattern, '^', 1) === 0) {
+                if (stripos($normalized, substr($pattern, 1)) === 0) {
+                    return true;
+                }
+            } elseif (stripos($normalized, $pattern) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Canonicalize separator spelling so alternate forms cannot evade matching.
+     *
+     * @param string $class
+     * @return string
+     */
+    private function normalize(string $class): string
+    {
+        $normalized = str_replace('/', '\\', trim($class));
+        while (strpos($normalized, '\\\\') !== false) {
+            $normalized = str_replace('\\\\', '\\', $normalized);
+        }
+
+        return ltrim($normalized, '\\');
+    }
+}

--- a/app/code/Magento/Email/Model/Template/Filter/BlockDirectivePolicy.php
+++ b/app/code/Magento/Email/Model/Template/Filter/BlockDirectivePolicy.php
@@ -52,8 +52,21 @@ class BlockDirectivePolicy
             return false;
         }
 
+        // A block that has plugins is instantiated as its generated interceptor, so exemptions
+        // are matched against the wrapped class name too. Restriction patterns keep matching the
+        // name as given, so an interceptor can never shed one.
+        $unwrapped = $this->stripInterceptorSuffix($normalized);
+
         foreach ($this->allowedClasses as $allowed) {
-            if (strcasecmp($normalized, $this->normalize((string)$allowed)) === 0) {
+            $allowedClass = $this->normalize((string)$allowed);
+
+            if ($allowedClass === '') {
+                continue;
+            }
+
+            if (strcasecmp($normalized, $allowedClass) === 0
+                || strcasecmp($unwrapped, $allowedClass) === 0
+            ) {
                 return false;
             }
         }
@@ -91,5 +104,23 @@ class BlockDirectivePolicy
         }
 
         return ltrim($normalized, '\\');
+    }
+
+    /**
+     * Drop a generated interceptor's suffix, leaving the class it wraps.
+     *
+     * @param string $class
+     * @return string
+     */
+    private function stripInterceptorSuffix(string $class): string
+    {
+        $suffix = '\\Interceptor';
+        $length = strlen($suffix);
+
+        if (strlen($class) > $length && substr_compare($class, $suffix, -$length, $length, true) === 0) {
+            return substr($class, 0, -$length);
+        }
+
+        return $class;
     }
 }

--- a/app/code/Magento/Email/Test/Unit/Block/Adminhtml/Template/PreviewTest.php
+++ b/app/code/Magento/Email/Test/Unit/Block/Adminhtml/Template/PreviewTest.php
@@ -14,6 +14,7 @@ use Magento\Email\Model\AbstractTemplate;
 use Magento\Email\Model\Template;
 use Magento\Email\Model\TemplateFactory;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\AuthorizationInterface;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\App\State;
 use Magento\Framework\DataObject;
@@ -139,8 +140,19 @@ class PreviewTest extends TestCase
 
         $context = $this->createPartialMock(
             Context::class,
-            ['getRequest', 'getEventManager', 'getScopeConfig', 'getDesignPackage', 'getStoreManager', 'getAppState']
+            [
+                'getRequest',
+                'getEventManager',
+                'getScopeConfig',
+                'getDesignPackage',
+                'getStoreManager',
+                'getAppState',
+                'getAuthorization'
+            ]
         );
+        $authorization = $this->createMock(AuthorizationInterface::class);
+        $authorization->method('isAllowed')->willReturn(true);
+        $context->expects($this->any())->method('getAuthorization')->willReturn($authorization);
         $context->expects($this->any())->method('getRequest')->willReturn($this->request);
         $context->expects($this->any())->method('getEventManager')->willReturn($eventManage);
         $context->expects($this->any())->method('getScopeConfig')->willReturn($scopeConfig);

--- a/app/code/Magento/Email/Test/Unit/Model/Template/Filter/BlockDirectivePolicyTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/Filter/BlockDirectivePolicyTest.php
@@ -89,6 +89,39 @@ class BlockDirectivePolicyTest extends TestCase
         );
     }
 
+    public function testExemptionAppliesToGeneratedInterceptor()
+    {
+        $policy = new BlockDirectivePolicy(
+            self::DEFAULT_PATTERNS,
+            ['Vendor\\CheckoutFields\\Block\\Adminhtml\\Order\\View\\Fields']
+        );
+
+        $this->assertFalse(
+            $policy->isRestricted('Vendor\\CheckoutFields\\Block\\Adminhtml\\Order\\View\\Fields\\Interceptor'),
+            'A block with plugins is instantiated as its interceptor; the exemption must still apply'
+        );
+        $this->assertFalse(
+            $policy->isRestricted('Vendor\\CheckoutFields\\Block\\Adminhtml\\Order\\View\\Fields\\interceptor'),
+            'The interceptor suffix is matched case-insensitively'
+        );
+    }
+
+    public function testInterceptorCannotShedARestriction()
+    {
+        $policy = new BlockDirectivePolicy(self::DEFAULT_PATTERNS);
+
+        $this->assertTrue(
+            $policy->isRestricted('Magento\\Backend\\Block\\Widget\\Grid\\ColumnSet\\Interceptor')
+        );
+        $this->assertTrue(
+            $policy->isRestricted('Vendor\\Module\\Block\\Adminhtml\\Foo\\Interceptor')
+        );
+        $this->assertTrue(
+            $policy->isRestricted('Vendor\\Module\\Block\\Adminhtml\\Interceptor'),
+            'Unwrapping must never move a class out of a restricted namespace'
+        );
+    }
+
     public function testUnconfiguredPolicyRestrictsNothing()
     {
         $policy = new BlockDirectivePolicy();

--- a/app/code/Magento/Email/Test/Unit/Model/Template/Filter/BlockDirectivePolicyTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/Filter/BlockDirectivePolicyTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright © Mage-OS. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Email\Test\Unit\Model\Template\Filter;
+
+use Magento\Email\Model\Template\Filter\BlockDirectivePolicy;
+use PHPUnit\Framework\TestCase;
+
+class BlockDirectivePolicyTest extends TestCase
+{
+    /**
+     * Mirrors the default configuration in Magento/Email/etc/di.xml.
+     */
+    private const DEFAULT_PATTERNS = [
+        '\\Block\\Adminhtml\\',
+        '\\Block\\Backend\\',
+        '\\Block\\System\\Config\\',
+        '^Magento\\Backend\\Block\\',
+        '^Magento\\User\\Block\\',
+    ];
+
+    public function testRestrictsDefaultPatternsInAllSeparatorForms()
+    {
+        $policy = new BlockDirectivePolicy(self::DEFAULT_PATTERNS);
+        $bs = chr(92);
+
+        $restricted = [
+            "Magento{$bs}Backend{$bs}Block{$bs}Widget{$bs}Grid{$bs}ColumnSet",
+            "{$bs}Magento{$bs}Backend{$bs}Block{$bs}Widget{$bs}Grid{$bs}ColumnSet",
+            "Magento{$bs}{$bs}Backend{$bs}{$bs}Block{$bs}{$bs}Widget{$bs}{$bs}Grid{$bs}{$bs}ColumnSet",
+            "Magento/Backend/Block/Widget/Grid/ColumnSet",
+            "  Magento{$bs}Email{$bs}Block{$bs}Adminhtml{$bs}Template{$bs}Preview  ",
+            "Magento{$bs}User{$bs}Block{$bs}Role{$bs}Grid{$bs}User",
+            "Magento{$bs}Indexer{$bs}Block{$bs}Backend{$bs}Container",
+            "Vendor{$bs}Module{$bs}Block{$bs}Backend{$bs}Anything",
+            "Magento{$bs}Config{$bs}Block{$bs}System{$bs}Config{$bs}Edit",
+            "Magento{$bs}Ups{$bs}Block{$bs}Backend{$bs}System{$bs}CarrierConfig",
+            "magento{$bs}backend{$bs}block{$bs}widget{$bs}grid{$bs}columnset",
+        ];
+        foreach ($restricted as $class) {
+            $this->assertTrue($policy->isRestricted($class), $class);
+        }
+
+        $allowed = [
+            "Magento{$bs}Cms{$bs}Block{$bs}Block",
+            "Magento{$bs}Framework{$bs}View{$bs}Element{$bs}Template",
+            "Vendor{$bs}Module{$bs}Block{$bs}SystemStatus",
+            "Vendor{$bs}Module{$bs}Block{$bs}BackendCompat{$bs}Widget",
+            '',
+            '   ',
+        ];
+        foreach ($allowed as $class) {
+            $this->assertFalse($policy->isRestricted($class), var_export($class, true));
+        }
+    }
+
+    public function testPrefixPatternDoesNotMatchMidName()
+    {
+        $policy = new BlockDirectivePolicy(['^Magento\\Backend\\Block\\']);
+
+        $this->assertFalse($policy->isRestricted('Vendor\\Magento\\Backend\\Block\\Foo'));
+        $this->assertTrue($policy->isRestricted('Magento\\Backend\\Block\\Foo'));
+    }
+
+    public function testExactAllowedClassIsExemptFromPatterns()
+    {
+        $policy = new BlockDirectivePolicy(
+            self::DEFAULT_PATTERNS,
+            ['Vendor\\CheckoutFields\\Block\\Adminhtml\\Order\\View\\Fields']
+        );
+
+        $this->assertFalse(
+            $policy->isRestricted('Vendor\\CheckoutFields\\Block\\Adminhtml\\Order\\View\\Fields')
+        );
+        $this->assertFalse(
+            $policy->isRestricted('Vendor/CheckoutFields/Block/Adminhtml/Order/View/Fields'),
+            'Exemption must match the same separator forms the deny patterns do'
+        );
+        $this->assertTrue(
+            $policy->isRestricted('Vendor\\CheckoutFields\\Block\\Adminhtml\\Order\\View\\FieldsExtra'),
+            'Exemption must not extend beyond the exact class'
+        );
+        $this->assertTrue(
+            $policy->isRestricted('Magento\\Backend\\Block\\Widget\\Grid\\ColumnSet')
+        );
+    }
+
+    public function testUnconfiguredPolicyRestrictsNothing()
+    {
+        $policy = new BlockDirectivePolicy();
+
+        $this->assertFalse($policy->isRestricted('Magento\\Backend\\Block\\Widget\\Grid\\ColumnSet'));
+    }
+}

--- a/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
@@ -12,6 +12,7 @@ use Magento\Backend\Model\Url as BackendModelUrl;
 use Magento\Backend\Model\UrlInterface;
 use Magento\Email\Model\Template\Css\Processor;
 use Magento\Email\Model\Template\Filter;
+use Magento\Email\Test\Unit\Model\Template\_files\Block\Adminhtml\RestrictedBlock;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -683,5 +684,70 @@ class FilterTest extends TestCase
                 'expectSetData' => false
             ]
         ];
+    }
+
+    /**
+     * A backend/adminhtml block class must never be instantiated from a template directive.
+     */
+    public function testBlockDirectiveRefusesBackendBlockClass()
+    {
+        $this->layout->expects($this->never())->method('createBlock');
+
+        $construction = [
+            '{{block class="Magento\\Backend\\Block\\Widget\\Grid\\ColumnSet"}}',
+            'block',
+            ' class="Magento\\Backend\\Block\\Widget\\Grid\\ColumnSet"'
+        ];
+
+        $filter = $this->getModel();
+        $this->assertSame('', $filter->blockDirective($construction));
+    }
+
+    /**
+     * The deny list is checked again on the instantiated object.
+     */
+    public function testBlockDirectiveRefusesRestrictedBlockResolvedByLayout()
+    {
+        $block = new RestrictedBlock();
+        $this->layout->expects($this->once())
+            ->method('createBlock')
+            ->with('Vendor\\Alias\\Block')
+            ->willReturn($block);
+
+        $construction = [
+            '{{block class="Vendor\\Alias\\Block"}}',
+            'block',
+            ' class="Vendor\\Alias\\Block"'
+        ];
+
+        $this->assertSame('', $this->getModel()->blockDirective($construction));
+        $this->assertFalse($block->rendered, 'A restricted block must not be rendered');
+    }
+
+    public function testIsRestrictedBlockClassCatchesAlternateSeparatorForms()
+    {
+        $filter = $this->getModel();
+        $method = new \ReflectionMethod(Filter::class, 'isRestrictedBlockClass');
+        $method->setAccessible(true);
+        $bs = chr(92);
+
+        $restricted = [
+            "Magento{$bs}Backend{$bs}Block{$bs}Widget{$bs}Grid{$bs}ColumnSet",
+            "{$bs}Magento{$bs}Backend{$bs}Block{$bs}Widget{$bs}Grid{$bs}ColumnSet",
+            "Magento{$bs}{$bs}Backend{$bs}{$bs}Block{$bs}{$bs}Widget{$bs}{$bs}Grid{$bs}{$bs}ColumnSet",
+            "Magento/Backend/Block/Widget/Grid/ColumnSet",
+            "  Magento{$bs}Email{$bs}Block{$bs}Adminhtml{$bs}Template{$bs}Preview  ",
+        ];
+        foreach ($restricted as $class) {
+            $this->assertTrue($method->invoke($filter, $class), $class);
+        }
+
+        $allowed = [
+            "Magento{$bs}Cms{$bs}Block{$bs}Block",
+            "Magento{$bs}Framework{$bs}View{$bs}Element{$bs}Template",
+        ];
+        foreach ($allowed as $class) {
+            $this->assertFalse($method->invoke($filter, $class), $class);
+        }
     }
 }

--- a/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
@@ -737,6 +737,11 @@ class FilterTest extends TestCase
             "Magento{$bs}{$bs}Backend{$bs}{$bs}Block{$bs}{$bs}Widget{$bs}{$bs}Grid{$bs}{$bs}ColumnSet",
             "Magento/Backend/Block/Widget/Grid/ColumnSet",
             "  Magento{$bs}Email{$bs}Block{$bs}Adminhtml{$bs}Template{$bs}Preview  ",
+            "Magento{$bs}User{$bs}Block{$bs}Role{$bs}Grid{$bs}User",
+            "Magento{$bs}Indexer{$bs}Block{$bs}Backend{$bs}Container",
+            "Vendor{$bs}Module{$bs}Block{$bs}Backend{$bs}Anything",
+            "Magento{$bs}Config{$bs}Block{$bs}System{$bs}Config{$bs}Edit",
+            "Magento{$bs}Ups{$bs}Block{$bs}Backend{$bs}System{$bs}CarrierConfig",
         ];
         foreach ($restricted as $class) {
             $this->assertTrue($method->invoke($filter, $class), $class);
@@ -745,9 +750,58 @@ class FilterTest extends TestCase
         $allowed = [
             "Magento{$bs}Cms{$bs}Block{$bs}Block",
             "Magento{$bs}Framework{$bs}View{$bs}Element{$bs}Template",
+            "Vendor{$bs}Module{$bs}Block{$bs}SystemStatus",
+            "Vendor{$bs}Module{$bs}Block{$bs}BackendCompat{$bs}Widget",
         ];
         foreach ($allowed as $class) {
             $this->assertFalse($method->invoke($filter, $class), $class);
         }
+    }
+
+    /**
+     * An "area" parameter on {{block}} must not reach the block.
+     */
+    public function testBlockDirectiveDropsAreaParameter()
+    {
+        $block = $this->getMockBuilder(AbstractBlock::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $block->method('hasData')->willReturn(true);
+        $block->method('toHtml')->willReturn('html');
+        $seen = [];
+        $block->method('setDataUsingMethod')
+            ->willReturnCallback(function ($key) use (&$seen, $block) {
+                $seen[] = $key;
+                return $block;
+            });
+
+        $this->layout->expects($this->once())
+            ->method('createBlock')
+            ->willReturn($block);
+
+        $construction = [
+            '{{block class="Magento\\Cms\\Block\\Block" area="adminhtml"}}',
+            'block',
+            ' class="Magento\\Cms\\Block\\Block" area="adminhtml"'
+        ];
+
+        $this->assertSame('html', $this->getModel()->blockDirective($construction));
+        $this->assertNotContains('area', $seen, 'The area parameter must be dropped');
+    }
+
+    /**
+     * The layout directive refuses adminhtml area emulation.
+     */
+    public function testLayoutDirectiveRefusesAdminhtmlArea()
+    {
+        $this->appState->expects($this->never())->method('emulateAreaCode');
+
+        $construction = [
+            '{{layout handle="adminhtml_email_template_popup" area="adminhtml"}}',
+            'layout',
+            ' handle="adminhtml_email_template_popup" area="adminhtml"'
+        ];
+
+        $this->assertSame('', $this->getModel()->layoutDirective($construction));
     }
 }

--- a/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
@@ -737,9 +737,54 @@ class FilterTest extends TestCase
     }
 
     /**
-     * An "area" parameter on {{block}} must not reach the block.
+     * A non-frontend "area" parameter on {{block}} must not reach the block.
      */
-    public function testBlockDirectiveDropsAreaParameter()
+    public function testBlockDirectiveDropsNonFrontendAreaParameter()
+    {
+        $block = $this->createRecordingBlock($seen);
+
+        $this->layout->expects($this->once())
+            ->method('createBlock')
+            ->willReturn($block);
+
+        $construction = [
+            '{{block class="Magento\\Cms\\Block\\Block" area="adminhtml"}}',
+            'block',
+            ' class="Magento\\Cms\\Block\\Block" area="adminhtml"'
+        ];
+
+        $this->assertSame('html', $this->getModel()->blockDirective($construction));
+        $this->assertNotContains('area', $seen, 'A non-frontend area parameter must be dropped');
+    }
+
+    /**
+     * A frontend "area" parameter on {{block}} is legitimate (core shipment emails use it) and must pass through.
+     */
+    public function testBlockDirectiveKeepsFrontendAreaParameter()
+    {
+        $block = $this->createRecordingBlock($seen);
+
+        $this->layout->expects($this->once())
+            ->method('createBlock')
+            ->willReturn($block);
+
+        $construction = [
+            '{{block class="Magento\\Cms\\Block\\Block" area="frontend"}}',
+            'block',
+            ' class="Magento\\Cms\\Block\\Block" area="frontend"'
+        ];
+
+        $this->assertSame('html', $this->getModel()->blockDirective($construction));
+        $this->assertContains('area', $seen, 'The frontend area parameter must be kept');
+    }
+
+    /**
+     * Build a block mock that records setDataUsingMethod keys into $seen.
+     *
+     * @param array|null $seen
+     * @return AbstractBlock
+     */
+    private function createRecordingBlock(?array &$seen)
     {
         $block = $this->getMockBuilder(AbstractBlock::class)
             ->disableOriginalConstructor()
@@ -753,18 +798,7 @@ class FilterTest extends TestCase
                 return $block;
             });
 
-        $this->layout->expects($this->once())
-            ->method('createBlock')
-            ->willReturn($block);
-
-        $construction = [
-            '{{block class="Magento\\Cms\\Block\\Block" area="adminhtml"}}',
-            'block',
-            ' class="Magento\\Cms\\Block\\Block" area="adminhtml"'
-        ];
-
-        $this->assertSame('html', $this->getModel()->blockDirective($construction));
-        $this->assertNotContains('area', $seen, 'The area parameter must be dropped');
+        return $block;
     }
 
     /**

--- a/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
@@ -816,4 +816,47 @@ class FilterTest extends TestCase
 
         $this->assertSame('', $this->getModel()->layoutDirective($construction));
     }
+
+    /**
+     * The directive tokenizer does not trim values, so padding must not slip past the area check.
+     */
+    public function testLayoutDirectiveRefusesAdminhtmlAreaWithSurroundingWhitespace()
+    {
+        $this->appState->expects($this->never())->method('emulateAreaCode');
+
+        foreach (['adminhtml ', ' adminhtml', " \tADMINHTML \t"] as $area) {
+            $construction = [
+                '{{layout handle="adminhtml_email_template_popup" area="' . $area . '"}}',
+                'layout',
+                ' handle="adminhtml_email_template_popup" area="' . $area . '"'
+            ];
+
+            $this->assertSame(
+                '',
+                $this->getModel()->layoutDirective($construction),
+                var_export($area, true) . ' must be refused'
+            );
+        }
+    }
+
+    /**
+     * A padded frontend area is still the frontend area and must survive.
+     */
+    public function testBlockDirectiveKeepsPaddedFrontendAreaParameter()
+    {
+        $block = $this->createRecordingBlock($seen);
+
+        $this->layout->expects($this->once())
+            ->method('createBlock')
+            ->willReturn($block);
+
+        $construction = [
+            '{{block class="Magento\\Cms\\Block\\Block" area=" frontend "}}',
+            'block',
+            ' class="Magento\\Cms\\Block\\Block" area=" frontend "'
+        ];
+
+        $this->assertSame('html', $this->getModel()->blockDirective($construction));
+        $this->assertContains('area', $seen, 'A padded frontend area parameter must be kept');
+    }
 }

--- a/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
@@ -12,6 +12,7 @@ use Magento\Backend\Model\Url as BackendModelUrl;
 use Magento\Backend\Model\UrlInterface;
 use Magento\Email\Model\Template\Css\Processor;
 use Magento\Email\Model\Template\Filter;
+use Magento\Email\Model\Template\Filter\BlockDirectivePolicy;
 use Magento\Email\Test\Unit\Model\Template\_files\Block\Adminhtml\RestrictedBlock;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -30,6 +31,7 @@ use Magento\Framework\Filter\DirectiveProcessor\LegacyDirective;
 use Magento\Framework\Filter\DirectiveProcessor\TemplateDirective;
 use Magento\Framework\Filter\VariableResolver\StrictResolver;
 use Magento\Framework\Stdlib\StringUtils;
+use Magento\Framework\Translate\Inline\StateInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\Asset\ContentProcessorInterface;
 use Magento\Framework\View\Asset\File;
@@ -54,6 +56,14 @@ use Psr\Log\LoggerInterface;
  */
 class FilterTest extends TestCase
 {
+    private const RESTRICTED_BLOCK_PATTERNS = [
+        '\\Block\\Adminhtml\\',
+        '\\Block\\Backend\\',
+        '\\Block\\System\\Config\\',
+        '^Magento\\Backend\\Block\\',
+        '^Magento\\User\\Block\\',
+    ];
+
     /**
      * @var ObjectManager
      */
@@ -272,7 +282,9 @@ class FilterTest extends TestCase
                     $this->cssInliner,
                     [],
                     $this->directiveProcessors,
-                    $this->storeInformation
+                    $this->storeInformation,
+                    $this->createMock(StateInterface::class),
+                    new BlockDirectivePolicy(self::RESTRICTED_BLOCK_PATTERNS)
                 ]
             )
             ->onlyMethods($mockedMethods)
@@ -722,40 +734,6 @@ class FilterTest extends TestCase
 
         $this->assertSame('', $this->getModel()->blockDirective($construction));
         $this->assertFalse($block->rendered, 'A restricted block must not be rendered');
-    }
-
-    public function testIsRestrictedBlockClassCatchesAlternateSeparatorForms()
-    {
-        $filter = $this->getModel();
-        $method = new \ReflectionMethod(Filter::class, 'isRestrictedBlockClass');
-        $method->setAccessible(true);
-        $bs = chr(92);
-
-        $restricted = [
-            "Magento{$bs}Backend{$bs}Block{$bs}Widget{$bs}Grid{$bs}ColumnSet",
-            "{$bs}Magento{$bs}Backend{$bs}Block{$bs}Widget{$bs}Grid{$bs}ColumnSet",
-            "Magento{$bs}{$bs}Backend{$bs}{$bs}Block{$bs}{$bs}Widget{$bs}{$bs}Grid{$bs}{$bs}ColumnSet",
-            "Magento/Backend/Block/Widget/Grid/ColumnSet",
-            "  Magento{$bs}Email{$bs}Block{$bs}Adminhtml{$bs}Template{$bs}Preview  ",
-            "Magento{$bs}User{$bs}Block{$bs}Role{$bs}Grid{$bs}User",
-            "Magento{$bs}Indexer{$bs}Block{$bs}Backend{$bs}Container",
-            "Vendor{$bs}Module{$bs}Block{$bs}Backend{$bs}Anything",
-            "Magento{$bs}Config{$bs}Block{$bs}System{$bs}Config{$bs}Edit",
-            "Magento{$bs}Ups{$bs}Block{$bs}Backend{$bs}System{$bs}CarrierConfig",
-        ];
-        foreach ($restricted as $class) {
-            $this->assertTrue($method->invoke($filter, $class), $class);
-        }
-
-        $allowed = [
-            "Magento{$bs}Cms{$bs}Block{$bs}Block",
-            "Magento{$bs}Framework{$bs}View{$bs}Element{$bs}Template",
-            "Vendor{$bs}Module{$bs}Block{$bs}SystemStatus",
-            "Vendor{$bs}Module{$bs}Block{$bs}BackendCompat{$bs}Widget",
-        ];
-        foreach ($allowed as $class) {
-            $this->assertFalse($method->invoke($filter, $class), $class);
-        }
     }
 
     /**

--- a/app/code/Magento/Email/Test/Unit/Model/Template/_files/Block/Adminhtml/RestrictedBlock.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/_files/Block/Adminhtml/RestrictedBlock.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © Mage-OS. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Email\Test\Unit\Model\Template\_files\Block\Adminhtml;
+
+use Magento\Framework\View\Element\BlockInterface;
+
+/**
+ * Fixture whose class name sits in a restricted namespace, standing in for a backend block that a
+ * DI preference or virtual type resolved from an innocuous-looking {{block class="..."}} value.
+ */
+class RestrictedBlock implements BlockInterface
+{
+    /**
+     * @var bool
+     */
+    public $rendered = false;
+
+    /**
+     * @inheritdoc
+     */
+    public function toHtml()
+    {
+        $this->rendered = true;
+
+        return 'RESTRICTED';
+    }
+}

--- a/app/code/Magento/Email/etc/di.xml
+++ b/app/code/Magento/Email/etc/di.xml
@@ -100,4 +100,15 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Email\Model\Template\Filter\BlockDirectivePolicy">
+        <arguments>
+            <argument name="restrictedPatterns" xsi:type="array">
+                <item name="block_adminhtml" xsi:type="string">\Block\Adminhtml\</item>
+                <item name="block_backend" xsi:type="string">\Block\Backend\</item>
+                <item name="block_system_config" xsi:type="string">\Block\System\Config\</item>
+                <item name="magento_backend_block" xsi:type="string">^Magento\Backend\Block\</item>
+                <item name="magento_user_block" xsi:type="string">^Magento\User\Block\</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Queue/Preview.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Queue/Preview.php
@@ -16,6 +16,11 @@ class Preview extends \Magento\Newsletter\Block\Adminhtml\Template\Preview
     /**
      * @var string
      */
+    protected const ADMIN_RESOURCE = 'Magento_Newsletter::queue';
+
+    /**
+     * @var string
+     */
     protected $profilerName = "newsletter_queue_proccessing";
 
     /**

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Template/Preview.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Template/Preview.php
@@ -25,6 +25,11 @@ use Magento\Newsletter\Model\SubscriberFactory;
 class Preview extends Widget
 {
     /**
+     * @var string
+     */
+    protected const ADMIN_RESOURCE = 'Magento_Newsletter::template';
+
+    /**
      * Name for profiler
      *
      * @var string
@@ -74,6 +79,10 @@ class Preview extends Widget
      */
     protected function _toHtml()
     {
+        if (!$this->_authorization->isAllowed(static::ADMIN_RESOURCE)) {
+            return '';
+        }
+
         /* @var $template \Magento\Newsletter\Model\Template */
         $template = $this->_templateFactory->create();
 

--- a/app/code/Magento/Newsletter/Test/Unit/Block/Adminhtml/Queue/PreviewTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Block/Adminhtml/Queue/PreviewTest.php
@@ -10,6 +10,7 @@ namespace Magento\Newsletter\Test\Unit\Block\Adminhtml\Queue;
 use Magento\Backend\Block\Template\Context;
 use Magento\Backend\Model\Session;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\AuthorizationInterface;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\State;
@@ -81,6 +82,10 @@ class PreviewTest extends TestCase
     protected function setUp(): void
     {
         $context = $this->createMock(Context::class);
+        $authorization = $this->createMock(AuthorizationInterface::class);
+        $authorization->method('isAllowed')->willReturn(true);
+        $context->expects($this->once())->method('getAuthorization')
+            ->willReturn($authorization);
         $eventManager = $this->createMock(ManagerInterface::class);
         $context->expects($this->once())->method('getEventManager')
             ->willReturn($eventManager);

--- a/app/code/Magento/Newsletter/Test/Unit/Block/Adminhtml/Template/PreviewTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Block/Adminhtml/Template/PreviewTest.php
@@ -11,6 +11,7 @@ use Magento\Backend\Block\Template\Context;
 use Magento\Backend\Model\Session;
 use Magento\Email\Model\AbstractTemplate;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\AuthorizationInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\App\TemplateTypesInterface;
@@ -118,8 +119,11 @@ class PreviewTest extends TestCase
         $context = $this->createPartialMock(
             Context::class,
             ['getRequest', 'getEventManager', 'getScopeConfig', 'getDesignPackage',
-                'getStoreManager', 'getAppState', 'getBackendSession', 'getEscaper']
+                'getStoreManager', 'getAppState', 'getBackendSession', 'getEscaper', 'getAuthorization']
         );
+        $authorization = $this->createMock(AuthorizationInterface::class);
+        $authorization->method('isAllowed')->willReturn(true);
+        $context->expects($this->any())->method('getAuthorization')->willReturn($authorization);
         $context->expects($this->any())->method('getRequest')->willReturn($this->requestMock);
         $context->expects($this->any())->method('getEventManager')->willReturn($eventManager);
         $context->expects($this->any())->method('getScopeConfig')->willReturn($scopeConfig);

--- a/dev/tests/integration/testsuite/Magento/Email/Model/Template/FilterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/Template/FilterTest.php
@@ -139,11 +139,6 @@ class FilterTest extends \PHPUnit\Framework\TestCase
                 'handle="email_template_test_handle" area="frontend"',
                 '<strong>Email content for frontend/Magento/default theme</strong>',
             ],
-            'area parameter - backend' => [
-                'frontend',
-                'handle="email_template_test_handle" area="adminhtml"',
-                '<strong>Email content for adminhtml/Magento/default theme</strong>',
-            ],
             'custom parameter' => [
                 'frontend',
                 'handle="email_template_test_handle" template="Magento_Email::sample_email_content_custom.phtml"',

--- a/lib/internal/Magento/Framework/Filesystem/SecurePathValidator.php
+++ b/lib/internal/Magento/Framework/Filesystem/SecurePathValidator.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Copyright © Mage-OS. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Filesystem;
+
+/**
+ * Rejects include/require targets pointing at stream wrappers or runtime-writable,
+ * non-code locations. Blocked directories are anchored to the application root (BP);
+ * directories relocated through MAGE_DIRS are not covered.
+ */
+class SecurePathValidator
+{
+    /**
+     * Runtime-writable locations relative to the application root. Nothing under them is code.
+     */
+    private const BLOCKED_DIRECTORIES = [
+        'var/report/',
+        'var/log/',
+        'var/tmp/',
+        'var/session/',
+        'var/cache/',
+        'var/page_cache/',
+        'var/importexport/',
+        'var/backups/',
+        'pub/media/',
+        'pub/static/',
+    ];
+
+    /**
+     * @var array<string, string[]>
+     */
+    private static $prefixCache = [];
+
+    /**
+     * Whether a path must not be include()d / require()d, anchored to the application root.
+     *
+     * @param string $path
+     * @return bool
+     */
+    public static function isUnsafeIncludePath(string $path): bool
+    {
+        return self::isUnsafeIncludePathForRoot($path, defined('BP') ? BP : null);
+    }
+
+    /**
+     * Whether a path must not be include()d / require()d, anchored to the given root.
+     *
+     * With a null root the blocked directories are matched anywhere in the path.
+     *
+     * @param string $path
+     * @param string|null $root
+     * @return bool
+     */
+    public static function isUnsafeIncludePathForRoot(string $path, ?string $root): bool
+    {
+        if ($path === '' || strpos($path, "\0") !== false || strpos($path, '://') !== false) {
+            return true;
+        }
+
+        $candidates = [self::normalize($path, $root)];
+        // Resolve symlinks and parent references only when present: keeps realpath() off the
+        // common template-render path.
+        if (strpos($path, '..') !== false) {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            $real = realpath($path);
+            if ($real !== false) {
+                $candidates[] = self::normalize($real, $root);
+            }
+        }
+
+        $anchored = $root !== null;
+        foreach (self::blockedPrefixes($root) as $prefix) {
+            foreach ($candidates as $candidate) {
+                $position = strpos($candidate, $prefix);
+                if ($position !== false && (!$anchored || $position === 0)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Lower-case, forward-slash form with repeated separators and "." segments collapsed.
+     *
+     * A relative path is resolved against the root when one is given.
+     *
+     * @param string $path
+     * @param string|null $root
+     * @return string
+     */
+    private static function normalize(string $path, ?string $root = null): string
+    {
+        $path = str_replace('\\', '/', $path);
+        if ($root !== null && !preg_match('#^(?:[a-zA-Z]:)?/#', $path)) {
+            $path = str_replace('\\', '/', $root) . '/' . $path;
+        }
+        $path = strtolower((string)preg_replace('#/+#', '/', $path));
+        while (strpos($path, '/./') !== false) {
+            $path = str_replace('/./', '/', $path);
+        }
+
+        return $path;
+    }
+
+    /**
+     * Blocked directory prefixes for a root: both its literal and resolved forms when they differ.
+     *
+     * @param string|null $root
+     * @return string[]
+     */
+    private static function blockedPrefixes(?string $root): array
+    {
+        $cacheKey = $root ?? '';
+        if (isset(self::$prefixCache[$cacheKey])) {
+            return self::$prefixCache[$cacheKey];
+        }
+
+        $roots = [''];
+        if ($root !== null) {
+            $roots = [rtrim(self::normalize($root), '/')];
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            $realRoot = realpath($root);
+            if ($realRoot !== false) {
+                $roots[] = rtrim(self::normalize($realRoot), '/');
+            }
+            $roots = array_unique($roots);
+        }
+
+        $prefixes = [];
+        foreach ($roots as $normalizedRoot) {
+            foreach (self::BLOCKED_DIRECTORIES as $directory) {
+                $prefixes[] = $normalizedRoot . '/' . $directory;
+            }
+        }
+
+        return self::$prefixCache[$cacheKey] = $prefixes;
+    }
+}

--- a/lib/internal/Magento/Framework/Filesystem/Test/Unit/SecurePathValidatorTest.php
+++ b/lib/internal/Magento/Framework/Filesystem/Test/Unit/SecurePathValidatorTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Copyright © Mage-OS. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Filesystem\Test\Unit;
+
+use Magento\Framework\Filesystem\SecurePathValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SecurePathValidatorTest extends TestCase
+{
+    private const ROOT = '/srv/site';
+
+    #[DataProvider('unsafeProvider')]
+    public function testUnsafePaths(string $path, ?string $root = self::ROOT): void
+    {
+        $this->assertTrue(SecurePathValidator::isUnsafeIncludePathForRoot($path, $root), $path);
+    }
+
+    /**
+     * @return array
+     */
+    public static function unsafeProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'null byte' => ["/srv/site/app/design/x.phtml\0.png"],
+            'phar wrapper' => ['phar:///tmp/x.phar/y.phtml'],
+            'php filter wrapper' => ['php://filter/resource=/etc/passwd'],
+            'var report' => ['/srv/site/var/report/deadbeef'],
+            'var log' => ['/srv/site/var/log/system.log'],
+            'var tmp' => ['/srv/site/var/tmp/x.phtml'],
+            'var cache' => ['/srv/site/var/cache/x.php'],
+            'var page_cache' => ['/srv/site/var/page_cache/x.php'],
+            'pub media' => ['/srv/site/pub/media/evil.phtml'],
+            'pub static' => ['/srv/site/pub/static/evil.phtml'],
+            'repeated separators' => ['/srv/site//var///report/x'],
+            'dot segments' => ['/srv/site/./var/./report/x'],
+            'mixed case' => ['/srv/site/VAR/Report/x'],
+            'relative to root' => ['var/report/x'],
+            'windows root' => ['C:\site\var\report\x', 'C:\site'],
+            'windows root trailing separator' => ['C:/site/var/report/x', 'C:\site\\'],
+            'root with trailing slash' => ['/srv/site/var/report/x', '/srv/site/'],
+            'unanchored fallback' => ['/srv/site/var/report/x', null],
+            'unanchored fallback nested install path' => ['/var/tmp/ci/app/design/frontend/V/t/x.phtml', null],
+        ];
+    }
+
+    #[DataProvider('safeProvider')]
+    public function testSafePaths(string $path, ?string $root = self::ROOT): void
+    {
+        $this->assertFalse(SecurePathValidator::isUnsafeIncludePathForRoot($path, $root), $path);
+    }
+
+    /**
+     * @return array
+     */
+    public static function safeProvider(): array
+    {
+        return [
+            'module view' => ['/srv/site/app/code/Vendor/Mod/view/frontend/templates/x.phtml'],
+            'theme view' => ['/srv/site/app/design/frontend/Vendor/theme/Module/templates/x.phtml'],
+            'vendor view' => ['/srv/site/vendor/magento/module-catalog/view/frontend/templates/x.phtml'],
+            'generated code' => ['/srv/site/generated/code/Magento/Cms/Block/Block/Interceptor.php'],
+            'report substring not a path segment' => ['/srv/site/app/code/Vendor/Reporting/view/x.phtml'],
+            'other var directory' => ['/srv/site/var/view_preprocessed/x.less'],
+            'blocked segment outside the root' => ['/other/var/report/x'],
+            'install rooted under /var/tmp' => [
+                '/var/tmp/ci/app/design/frontend/V/t/Magento_Theme/templates/html/header.phtml',
+                '/var/tmp/ci',
+            ],
+            'install rooted under /var/cache' => [
+                '/var/cache/build/vendor/magento/module-theme/view/frontend/templates/x.phtml',
+                '/var/cache/build',
+            ],
+            'blocked segment inside a module path under such an install' => [
+                '/var/tmp/ci/app/code/Vendor/Mod/var/report/x.phtml',
+                '/var/tmp/ci',
+            ],
+        ];
+    }
+
+    public function testDefaultRootIsApplicationRoot(): void
+    {
+        $this->assertTrue(defined('BP'), 'The unit bootstrap must define BP');
+        $this->assertTrue(SecurePathValidator::isUnsafeIncludePath(BP . '/var/report/deadbeef'));
+        $this->assertTrue(SecurePathValidator::isUnsafeIncludePath(BP . '/var/page_cache/x.php'));
+        $this->assertFalse(SecurePathValidator::isUnsafeIncludePath(BP . '/app/code/Vendor/Mod/view/x.phtml'));
+        $this->assertFalse(SecurePathValidator::isUnsafeIncludePath('/other/var/report/deadbeef'));
+    }
+
+    public function testTraversalIntoBlockedDirectoryIsResolved(): void
+    {
+        $base = sys_get_temp_dir() . '/mageos_spv_' . uniqid();
+        mkdir($base . '/var/report', 0777, true);
+        mkdir($base . '/app/code', 0777, true);
+        $target = $base . '/var/report/deadbeef';
+        file_put_contents($target, 'x');
+
+        try {
+            $traversal = $base . '/app/code/../../var/report/deadbeef';
+            $this->assertTrue(SecurePathValidator::isUnsafeIncludePathForRoot($traversal, $base));
+            $this->assertFalse(
+                SecurePathValidator::isUnsafeIncludePathForRoot($base . '/app/code/../code/x.phtml', $base)
+            );
+        } finally {
+            $this->removeFile($target);
+            $this->removeDir($base . '/var/report');
+            $this->removeDir($base . '/var');
+            $this->removeDir($base . '/app/code');
+            $this->removeDir($base . '/app');
+            $this->removeDir($base);
+        }
+    }
+
+    /**
+     * @param string $file
+     * @return void
+     */
+    private function removeFile(string $file): void
+    {
+        if (is_file($file)) {
+            unlink($file);
+        }
+    }
+
+    /**
+     * @param string $dir
+     * @return void
+     */
+    private function removeDir(string $dir): void
+    {
+        if (is_dir($dir)) {
+            rmdir($dir);
+        }
+    }
+}

--- a/lib/internal/Magento/Framework/Filter/Template.php
+++ b/lib/internal/Magento/Framework/Filter/Template.php
@@ -16,6 +16,7 @@ use Magento\Framework\Filter\DirectiveProcessor\LegacyDirective;
 use Magento\Framework\Filter\DirectiveProcessor\TemplateDirective;
 use Magento\Framework\Filter\DirectiveProcessor\VarDirective;
 use Magento\Framework\Stdlib\StringUtils;
+use Magento\Framework\Filter\Template\DirectiveOutputNeutralizer;
 use Magento\Framework\Filter\Template\SignatureProvider;
 use Magento\Framework\Filter\Template\FilteringDepthMeter;
 
@@ -111,12 +112,18 @@ class Template implements FilterInterface
     private $filteringDepthMeter;
 
     /**
+     * @var DirectiveOutputNeutralizer|null
+     */
+    private $directiveOutputNeutralizer;
+
+    /**
      * @param StringUtils $string
      * @param array $variables
      * @param DirectiveProcessorInterface[] $directiveProcessors
      * @param VariableResolverInterface|null $variableResolver
      * @param SignatureProvider|null $signatureProvider
      * @param FilteringDepthMeter|null $filteringDepthMeter
+     * @param DirectiveOutputNeutralizer|null $directiveOutputNeutralizer
      */
     public function __construct(
         StringUtils $string,
@@ -124,7 +131,8 @@ class Template implements FilterInterface
         $directiveProcessors = [],
         ?VariableResolverInterface $variableResolver = null,
         ?SignatureProvider $signatureProvider = null,
-        ?FilteringDepthMeter $filteringDepthMeter = null
+        ?FilteringDepthMeter $filteringDepthMeter = null,
+        ?DirectiveOutputNeutralizer $directiveOutputNeutralizer = null
     ) {
         $this->string = $string;
         $this->setVariables($variables);
@@ -137,6 +145,9 @@ class Template implements FilterInterface
 
         $this->filteringDepthMeter = $filteringDepthMeter ?? ObjectManager::getInstance()
                 ->get(FilteringDepthMeter::class);
+
+        $this->directiveOutputNeutralizer = $directiveOutputNeutralizer ?? ObjectManager::getInstance()
+                ->get(DirectiveOutputNeutralizer::class);
 
         if (empty($directiveProcessors)) {
             $this->directiveProcessors = [
@@ -273,6 +284,11 @@ class Template implements FilterInterface
             if (preg_match_all($pattern, $value, $constructions, PREG_SET_ORDER)) {
                 foreach ($constructions as $construction) {
                     $replacedValue = $directiveProcessor->process($construction, $this, $this->templateVars);
+
+                    if ($replacedValue !== $construction[0]) {
+                        // Resolved output is data: encode directive openers. Deferred directives pass through.
+                        $replacedValue = $this->directiveOutputNeutralizer->neutralize($replacedValue);
+                    }
 
                     $result = [
                         'directive' => $construction[0],

--- a/lib/internal/Magento/Framework/Filter/Template.php
+++ b/lib/internal/Magento/Framework/Filter/Template.php
@@ -117,6 +117,14 @@ class Template implements FilterInterface
     private $directiveOutputNeutralizer;
 
     /**
+     * Directives this filter has explicitly deferred to its parent template. Only these are
+     * signed; an unresolvable directive that merely comes back unchanged is not deferred.
+     *
+     * @var string[]
+     */
+    private $deferredDirectives = [];
+
+    /**
      * @param StringUtils $string
      * @param array $variables
      * @param DirectiveProcessorInterface[] $directiveProcessors
@@ -214,6 +222,11 @@ class Template implements FilterInterface
 
         $this->filteringDepthMeter->descend();
 
+        // filter() is re-entrant (directives filter their own bodies); deferrals recorded
+        // by an outer invocation must not leak into this one.
+        $outerDeferredDirectives = $this->deferredDirectives;
+        $this->deferredDirectives = [];
+
         // Processing of template directives.
         $templateDirectivesResults = array_unique(
             $this->processDirectives($value),
@@ -231,12 +244,14 @@ class Template implements FilterInterface
 
         $value = $this->applyDirectivesResults($value, $deferredDirectivesResults);
 
-        if ($this->filteringDepthMeter->showMark() > 1) {
+        if ($this->filteringDepthMeter->showMark() > 1 && $this->deferredDirectives) {
             // Signing own deferred directives (if any).
             $signature = $this->signatureProvider->get();
 
             foreach ($templateDirectivesResults as $result) {
-                if ($result['directive'] === $result['output']) {
+                if ($result['directive'] === $result['output']
+                    && in_array($result['directive'], $this->deferredDirectives, true)
+                ) {
                     $value = str_replace(
                         $result['output'],
                         $signature . $result['output'] . $signature,
@@ -246,11 +261,27 @@ class Template implements FilterInterface
             }
         }
 
+        $this->deferredDirectives = $outerDeferredDirectives;
+
         $value = $this->afterFilter($value);
 
         $this->filteringDepthMeter->ascend();
 
         return $value;
+    }
+
+    /**
+     * Marks a directive as deferred to the parent template.
+     *
+     * A directive processor that returns its construction unchanged so the parent processes
+     * it instead must declare that here; only declared directives are signed.
+     *
+     * @param string $directive
+     * @return void
+     */
+    public function deferToParent(string $directive): void
+    {
+        $this->deferredDirectives[] = $directive;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Filter/Template/DirectiveOutputNeutralizer.php
+++ b/lib/internal/Magento/Framework/Filter/Template/DirectiveOutputNeutralizer.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright © Mage-OS. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Filter\Template;
+
+/**
+ * Encodes directive openers in the output produced by a resolved template directive, so that
+ * resolved output is never re-parsed as a directive by a later filtering pass. Signed deferred
+ * directives are left untouched.
+ *
+ * A transformation that decodes HTML entities (such as a DOM round-trip) undoes the encoding;
+ * the "enabled" DI argument turns the behavior off for output that cannot tolerate it.
+ */
+class DirectiveOutputNeutralizer
+{
+    private const OPENING_DELIMITER = '{{';
+
+    private const ENCODED_OPENING_DELIMITER = '&#123;&#123;';
+
+    private const ENCODED_BRACE = '&#123;';
+
+    /**
+     * @var SignatureProvider
+     */
+    private $signatureProvider;
+
+    /**
+     * @var bool
+     */
+    private $enabled;
+
+    /**
+     * @param SignatureProvider $signatureProvider
+     * @param bool $enabled
+     */
+    public function __construct(SignatureProvider $signatureProvider, bool $enabled = true)
+    {
+        $this->signatureProvider = $signatureProvider;
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * Whether resolved directive output is neutralized.
+     *
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Encode directive openers in resolved output, preserving signed deferred directives.
+     *
+     * @param string $output
+     * @return string
+     */
+    public function neutralize(string $output): string
+    {
+        if (!$this->enabled || strpos($output, '{') === false) {
+            return $output;
+        }
+
+        $signature = $this->signatureProvider->get();
+        if ($signature === '' || strpos($output, $signature) === false) {
+            return $this->encode($output);
+        }
+
+        $quotedSignature = preg_quote($signature, '/');
+        $parts = preg_split(
+            '/(' . $quotedSignature . '.*?' . $quotedSignature . ')/s',
+            $output,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE
+        );
+        if ($parts === false) {
+            return $this->encode($output);
+        }
+
+        // Odd indexes hold the captured signed spans; even indexes hold the data between them.
+        foreach ($parts as $index => $part) {
+            if ($index % 2 === 0) {
+                $parts[$index] = $this->encode($part);
+            }
+        }
+
+        return implode('', $parts);
+    }
+
+    /**
+     * Encode every "{{" and any single "{" at either edge of the segment.
+     *
+     * @param string $segment
+     * @return string
+     */
+    private function encode(string $segment): string
+    {
+        if ($segment === '') {
+            return $segment;
+        }
+
+        $segment = str_replace(self::OPENING_DELIMITER, self::ENCODED_OPENING_DELIMITER, $segment);
+
+        if ($segment[0] === '{') {
+            $segment = self::ENCODED_BRACE . substr($segment, 1);
+        }
+        if (substr($segment, -1) === '{') {
+            $segment = substr($segment, 0, -1) . self::ENCODED_BRACE;
+        }
+
+        return $segment;
+    }
+}

--- a/lib/internal/Magento/Framework/Filter/Test/Unit/Template/DirectiveOutputNeutralizerTest.php
+++ b/lib/internal/Magento/Framework/Filter/Test/Unit/Template/DirectiveOutputNeutralizerTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright © Mage-OS. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Filter\Test\Unit\Template;
+
+use Magento\Framework\Filter\Template\DirectiveOutputNeutralizer;
+use Magento\Framework\Filter\Template\SignatureProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class DirectiveOutputNeutralizerTest extends TestCase
+{
+    private const SIGNATURE = 'Z0FFbeCU2R8bsVGJuTdkXyiiZBzsaceV';
+
+    /**
+     * @var DirectiveOutputNeutralizer
+     */
+    private $neutralizer;
+
+    protected function setUp(): void
+    {
+        $signatureProvider = $this->createPartialMock(SignatureProvider::class, ['get']);
+        $signatureProvider->method('get')->willReturn(self::SIGNATURE);
+
+        $this->neutralizer = new DirectiveOutputNeutralizer($signatureProvider);
+    }
+
+    /**
+     * @param string $output
+     * @param string $expected
+     */
+    #[DataProvider('neutralizeDataProvider')]
+    public function testNeutralize(string $output, string $expected): void
+    {
+        $this->assertSame($expected, $this->neutralizer->neutralize($output));
+    }
+
+    /**
+     * @return array
+     */
+    public static function neutralizeDataProvider(): array
+    {
+        $signed = self::SIGNATURE . '{{inlinecss file="css/email-inline.css"}}' . self::SIGNATURE;
+
+        return [
+            'no braces passes through' => ['plain <b>text</b>', 'plain <b>text</b>'],
+            'opener is encoded' => ['{{var secret}}', '&#123;&#123;var secret}}'],
+            'every opener is encoded' => ['{{a}} and {{b}}', '&#123;&#123;a}} and &#123;&#123;b}}'],
+            'closer alone is untouched (CSS)' => [
+                '@media (max-width:600px){.a{color:red}}',
+                '@media (max-width:600px){.a{color:red}}',
+            ],
+            'closer alone is untouched (JSON)' => [
+                '{"*":{"Magento_Ui/js/core/app":{"components":{}}}}',
+                '&#123;"*":{"Magento_Ui/js/core/app":{"components":{}}}}',
+            ],
+            'leading edge brace is encoded' => ['{block class="X"}}', '&#123;block class="X"}}'],
+            'trailing edge brace is encoded' => ['name{', 'name&#123;'],
+            'single brace output' => ['{', '&#123;'],
+            'triple brace leaves one inner brace' => ['a{{{b', 'a&#123;&#123;{b'],
+            'signed deferred directive is preserved' => [
+                'before {{x}} ' . $signed . ' after {{y}}',
+                'before &#123;&#123;x}} ' . $signed . ' after &#123;&#123;y}}',
+            ],
+            'adjacent signed spans are both preserved' => [
+                $signed . $signed . '{{z}}',
+                $signed . $signed . '&#123;&#123;z}}',
+            ],
+            'segments adjacent to signed span have edges encoded' => [
+                'a{' . $signed . '{b',
+                'a&#123;' . $signed . '&#123;b',
+            ],
+            'unpaired signature is treated as data' => [
+                self::SIGNATURE . '{{x}}',
+                self::SIGNATURE . '&#123;&#123;x}}',
+            ],
+        ];
+    }
+
+    public function testNeutralizeIsIdempotent(): void
+    {
+        $once = $this->neutralizer->neutralize('{{var a}}{ {{var b}} }{');
+
+        $this->assertSame($once, $this->neutralizer->neutralize($once));
+    }
+
+    public function testDisabledNeutralizerPassesOutputThrough(): void
+    {
+        $signatureProvider = $this->createPartialMock(SignatureProvider::class, ['get']);
+        $signatureProvider->expects($this->never())->method('get');
+
+        $neutralizer = new DirectiveOutputNeutralizer($signatureProvider, false);
+
+        $this->assertFalse($neutralizer->isEnabled());
+        $this->assertSame('{{var secret}}', $neutralizer->neutralize('{{var secret}}'));
+    }
+
+    public function testEnabledByDefault(): void
+    {
+        $this->assertTrue($this->neutralizer->isEnabled());
+    }
+}

--- a/lib/internal/Magento/Framework/Filter/Test/Unit/TemplateTest.php
+++ b/lib/internal/Magento/Framework/Filter/Test/Unit/TemplateTest.php
@@ -12,7 +12,13 @@ use Magento\Framework\Filter\DirectiveProcessor\DependDirective;
 use Magento\Framework\Filter\DirectiveProcessor\IfDirective;
 use Magento\Framework\Filter\DirectiveProcessor\LegacyDirective;
 use Magento\Framework\Filter\DirectiveProcessor\TemplateDirective;
+use Magento\Framework\Filter\DirectiveProcessorInterface;
 use Magento\Framework\Filter\Template;
+use Magento\Framework\Filter\Template\DirectiveOutputNeutralizer;
+use Magento\Framework\Filter\Template\FilteringDepthMeter;
+use Magento\Framework\Filter\Template\SignatureProvider;
+use Magento\Framework\Filter\VariableResolverInterface;
+use Magento\Framework\Stdlib\StringUtils;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Model\Store;
 use PHPUnit\Framework\TestCase;
@@ -88,7 +94,8 @@ class TemplateTest extends TestCase
             \Magento\Framework\Filter\Template::class,
             [
                 'signatureProvider' => $this->signatureProvider,
-                'filteringDepthMeter' => $this->filteringDepthMeter
+                'filteringDepthMeter' => $this->filteringDepthMeter,
+                'directiveOutputNeutralizer' => new DirectiveOutputNeutralizer($this->signatureProvider)
             ]
         );
     }
@@ -290,5 +297,226 @@ TEMPLATE;
 
         $dataObject->setAllVisibleItems($visibleItems);
         return $dataObject;
+    }
+
+    /**
+     * Resolved directive output is data: a "{{" inside it must not be parsed as a directive by a
+     * later top-level filter() call, while directives in the template text itself still resolve
+     * (the Catalog\Helper\Output case, where an attribute value is the template).
+     */
+    public function testResolvedOutputIsNotReparsedByLaterFilter(): void
+    {
+        $filter = $this->createFilter(
+            [$this->createVarProcessor()],
+            new FilteringDepthMeter(),
+            new DirectiveOutputNeutralizer($this->signatureProvider)
+        );
+        $filter->setVariables(['greeting' => 'Hi', 'payload' => '{{var secret}}', 'secret' => 'LEAKED']);
+
+        $first = $filter->filter('{{var greeting}} {{var payload}}');
+
+        $this->assertSame('Hi &#123;&#123;var secret}}', $first);
+        $this->assertSame($first, $filter->filter($first));
+    }
+
+    /**
+     * Within a single filter() call, applyDirectivesResults() replaces every occurrence of a
+     * directive's text. A value that repeats a sibling directive must not have that copy resolved.
+     */
+    public function testSiblingDirectiveCopiedThroughResolvedOutputIsNotResolvedInSameCall(): void
+    {
+        $filter = $this->createFilter(
+            [$this->createVarProcessor()],
+            new FilteringDepthMeter(),
+            new DirectiveOutputNeutralizer($this->signatureProvider)
+        );
+        $filter->setVariables(['payload' => '{{var secret}}', 'secret' => 'LEAKED']);
+
+        $this->assertSame('&#123;&#123;var secret}} LEAKED', $filter->filter('{{var payload}} {{var secret}}'));
+    }
+
+    /**
+     * Two adjacent substitutions must not be able to assemble a "{{" opener between them.
+     */
+    public function testEdgeBracesFromAdjacentDirectivesCannotFormDirective(): void
+    {
+        $filter = $this->createFilter(
+            [$this->createVarProcessor()],
+            new FilteringDepthMeter(),
+            new DirectiveOutputNeutralizer($this->signatureProvider)
+        );
+        $filter->setVariables(['a' => 'x{', 'b' => '{var secret}}', 'secret' => 'LEAKED']);
+
+        $first = $filter->filter('{{var a}}{{var b}}');
+
+        $this->assertSame('x&#123;&#123;var secret}}', $first);
+        $this->assertSame($first, $filter->filter($first));
+    }
+
+    /**
+     * A deferred directive returned by a child scope inside a resolved include (the {{template}}
+     * plus {{inlinecss}} shape) must stay intact and be processed by the parent, while "}}" in
+     * legitimate CSS output and "{{" from resolved data are handled as data.
+     */
+    public function testSignedDeferredDirectiveInsideResolvedOutputIsStillProcessed(): void
+    {
+        $depthMeter = new FilteringDepthMeter();
+        $neutralizer = new DirectiveOutputNeutralizer($this->signatureProvider);
+
+        $child = $this->createFilter(
+            [$this->createVarProcessor(), $this->createDeferProcessor(null)],
+            $depthMeter,
+            $neutralizer
+        );
+        $child->setVariables(['payload' => '{{var secret}}', 'secret' => 'LEAKED']);
+        $childText = '<style>.a{color:red}}</style>{{defer}}{{var payload}}';
+
+        $parent = $this->createFilter(
+            [
+                $this->createIncludeProcessor($child, $childText),
+                $this->createVarProcessor(),
+                $this->createDeferProcessor('DEFERRED-OK'),
+            ],
+            $depthMeter,
+            $neutralizer
+        );
+        $parent->setVariables(['secret' => 'LEAKED']);
+
+        $result = $parent->filter('[{{include}}]');
+
+        $this->assertSame('[<style>.a{color:red}}</style>DEFERRED-OK&#123;&#123;var secret}}]', $result);
+        $this->assertSame(0, $depthMeter->showMark());
+    }
+
+    /**
+     * With the neutralizer disabled the previous behavior is restored: resolved output is
+     * substituted verbatim and a second top-level filter() re-parses it.
+     */
+    public function testDisabledNeutralizerRestoresPriorBehavior(): void
+    {
+        $filter = $this->createFilter(
+            [$this->createVarProcessor()],
+            new FilteringDepthMeter(),
+            new DirectiveOutputNeutralizer($this->signatureProvider, false)
+        );
+        $filter->setVariables(['payload' => '{{var secret}}', 'secret' => 'LEAKED']);
+
+        $first = $filter->filter('{{var payload}}');
+
+        $this->assertSame('{{var secret}}', $first);
+        $this->assertSame('LEAKED', $filter->filter($first));
+        $this->assertSame('LEAKED LEAKED', $filter->filter('{{var payload}} {{var secret}}'));
+    }
+
+    /**
+     * @param DirectiveProcessorInterface[] $processors
+     * @param FilteringDepthMeter $depthMeter
+     * @param DirectiveOutputNeutralizer $neutralizer
+     * @return Template
+     */
+    private function createFilter(
+        array $processors,
+        FilteringDepthMeter $depthMeter,
+        DirectiveOutputNeutralizer $neutralizer
+    ): Template {
+        return new Template(
+            new StringUtils(),
+            [],
+            $processors,
+            $this->createMock(VariableResolverInterface::class),
+            $this->signatureProvider,
+            $depthMeter,
+            $neutralizer
+        );
+    }
+
+    /**
+     * Minimal {{var name}} processor that returns the variable verbatim, like VarDirective.
+     *
+     * @return DirectiveProcessorInterface
+     */
+    private function createVarProcessor(): DirectiveProcessorInterface
+    {
+        return new class implements DirectiveProcessorInterface {
+            public function process(array $construction, Template $filter, array $templateVariables): string
+            {
+                return (string)($templateVariables[$construction[1]] ?? '');
+            }
+
+            public function getRegularExpression(): string
+            {
+                return '/{{var (\w+)}}/';
+            }
+        };
+    }
+
+    /**
+     * {{defer}} processor: passes the directive through unchanged (to be signed and deferred to
+     * the parent) when $resolved is null, otherwise resolves to $resolved.
+     *
+     * @param string|null $resolved
+     * @return DirectiveProcessorInterface
+     */
+    private function createDeferProcessor(?string $resolved): DirectiveProcessorInterface
+    {
+        return new class ($resolved) implements DirectiveProcessorInterface {
+            /**
+             * @var string|null
+             */
+            private $resolved;
+
+            public function __construct(?string $resolved)
+            {
+                $this->resolved = $resolved;
+            }
+
+            public function process(array $construction, Template $filter, array $templateVariables): string
+            {
+                return $this->resolved ?? $construction[0];
+            }
+
+            public function getRegularExpression(): string
+            {
+                return '/{{defer}}/';
+            }
+        };
+    }
+
+    /**
+     * {{include}} processor: filters $text through a child filter, like the {{template}} directive.
+     *
+     * @param Template $child
+     * @param string $text
+     * @return DirectiveProcessorInterface
+     */
+    private function createIncludeProcessor(Template $child, string $text): DirectiveProcessorInterface
+    {
+        return new class ($child, $text) implements DirectiveProcessorInterface {
+            /**
+             * @var Template
+             */
+            private $child;
+
+            /**
+             * @var string
+             */
+            private $text;
+
+            public function __construct(Template $child, string $text)
+            {
+                $this->child = $child;
+                $this->text = $text;
+            }
+
+            public function process(array $construction, Template $filter, array $templateVariables): string
+            {
+                return $this->child->filter($this->text);
+            }
+
+            public function getRegularExpression(): string
+            {
+                return '/{{include}}/';
+            }
+        };
     }
 }

--- a/lib/internal/Magento/Framework/Filter/Test/Unit/TemplateTest.php
+++ b/lib/internal/Magento/Framework/Filter/Test/Unit/TemplateTest.php
@@ -409,6 +409,108 @@ TEMPLATE;
     }
 
     /**
+     * A directive that merely comes back unchanged from a child scope is not deferred: it must
+     * not be signed, and the parent must not execute it.
+     */
+    public function testUndeclaredUnchangedDirectiveIsNotSigned(): void
+    {
+        $depthMeter = new FilteringDepthMeter();
+        $neutralizer = new DirectiveOutputNeutralizer($this->signatureProvider);
+
+        $child = $this->createFilter(
+            [$this->createPassThroughProcessor()],
+            $depthMeter,
+            $neutralizer
+        );
+
+        $parent = $this->createFilter(
+            [
+                $this->createIncludeProcessor($child, 'a {{passthrough}} b'),
+                $this->createPassThroughProcessor('EXECUTED'),
+            ],
+            $depthMeter,
+            $neutralizer
+        );
+
+        $result = $parent->filter('[{{include}}]');
+
+        $this->assertStringNotContainsString('EXECUTED', $result);
+        $this->assertStringNotContainsString($this->signatureProvider->get(), $result);
+        $this->assertSame(0, $depthMeter->showMark());
+    }
+
+    /**
+     * Declared deferrals recorded by a child invocation must not leak into the parent
+     * invocation's own signing pass.
+     */
+    public function testDeclaredDeferralsDoNotLeakAcrossInvocations(): void
+    {
+        $depthMeter = new FilteringDepthMeter();
+        $neutralizer = new DirectiveOutputNeutralizer($this->signatureProvider);
+
+        $inner = $this->createFilter(
+            [$this->createDeferProcessor(null)],
+            $depthMeter,
+            $neutralizer
+        );
+        $middle = $this->createFilter(
+            [
+                $this->createIncludeProcessor($inner, '{{defer}}'),
+                $this->createPassThroughProcessor(),
+            ],
+            $depthMeter,
+            $neutralizer
+        );
+        $outer = $this->createFilter(
+            [
+                $this->createIncludeProcessor($middle, '{{include}} {{passthrough}}'),
+                $this->createDeferProcessor('DEFERRED-OK'),
+                $this->createPassThroughProcessor('EXECUTED'),
+            ],
+            $depthMeter,
+            $neutralizer
+        );
+
+        $result = $outer->filter('[{{include}}]');
+
+        $this->assertStringContainsString('DEFERRED-OK', $result);
+        $this->assertStringNotContainsString('EXECUTED', $result);
+        $this->assertSame(0, $depthMeter->showMark());
+    }
+
+    /**
+     * {{passthrough}} processor: returns the directive unchanged without declaring deferral
+     * when $resolved is null, otherwise resolves to $resolved.
+     *
+     * @param string|null $resolved
+     * @return DirectiveProcessorInterface
+     */
+    private function createPassThroughProcessor(?string $resolved = null): DirectiveProcessorInterface
+    {
+        return new class ($resolved) implements DirectiveProcessorInterface {
+            /**
+             * @var string|null
+             */
+            private $resolved;
+
+            public function __construct(?string $resolved)
+            {
+                $this->resolved = $resolved;
+            }
+
+            public function process(array $construction, Template $filter, array $templateVariables): string
+            {
+                return $this->resolved ?? $construction[0];
+            }
+
+            public function getRegularExpression(): string
+            {
+                return '/{{passthrough}}/';
+            }
+        };
+    }
+
+    /**
      * @param DirectiveProcessorInterface[] $processors
      * @param FilteringDepthMeter $depthMeter
      * @param DirectiveOutputNeutralizer $neutralizer
@@ -451,8 +553,8 @@ TEMPLATE;
     }
 
     /**
-     * {{defer}} processor: passes the directive through unchanged (to be signed and deferred to
-     * the parent) when $resolved is null, otherwise resolves to $resolved.
+     * {{defer}} processor: declares deferral and passes the directive through unchanged (to be
+     * signed and deferred to the parent) when $resolved is null, otherwise resolves to $resolved.
      *
      * @param string|null $resolved
      * @return DirectiveProcessorInterface
@@ -472,6 +574,10 @@ TEMPLATE;
 
             public function process(array $construction, Template $filter, array $templateVariables): string
             {
+                if ($this->resolved === null) {
+                    $filter->deferToParent($construction[0]);
+                }
+
                 return $this->resolved ?? $construction[0];
             }
 

--- a/lib/internal/Magento/Framework/View/Element/BlockFactory.php
+++ b/lib/internal/Magento/Framework/View/Element/BlockFactory.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Framework\View\Element;
 
+use Magento\Framework\ObjectManager\ConfigInterface;
 use Magento\Framework\ObjectManagerInterface;
 
 /**
@@ -21,13 +22,23 @@ class BlockFactory
     protected $objectManager;
 
     /**
+     * @var ConfigInterface
+     */
+    private $objectManagerConfig;
+
+    /**
      * Constructor
      *
      * @param ObjectManagerInterface $objectManager
+     * @param ConfigInterface|null $objectManagerConfig
      */
-    public function __construct(ObjectManagerInterface $objectManager)
-    {
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        ?ConfigInterface $objectManagerConfig = null
+    ) {
         $this->objectManager = $objectManager;
+        $this->objectManagerConfig = $objectManagerConfig ?:
+            \Magento\Framework\App\ObjectManager::getInstance()->get(ConfigInterface::class);
     }
 
     /**
@@ -45,10 +56,13 @@ class BlockFactory
     public function createBlock($blockName, array $arguments = [])
     {
         $blockName = ltrim($blockName, '\\');
-        $block = $this->objectManager->create($blockName, $arguments);
-        if (!$block instanceof BlockInterface) {
+        $resolvedType = $this->objectManagerConfig->getInstanceType(
+            $this->objectManagerConfig->getPreference($blockName)
+        );
+        if (!is_a($resolvedType, BlockInterface::class, true)) {
             throw new \LogicException($blockName . ' does not implement BlockInterface');
         }
+        $block = $this->objectManager->create($blockName, $arguments);
         if ($block instanceof Template) {
             $block->setTemplateContext($block);
         }

--- a/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
@@ -277,7 +277,7 @@ class Block implements Layout\GeneratorInterface
         if ($block && is_string($block)) {
             try {
                 $block = $this->blockFactory->createBlock($block, $arguments);
-            } catch (\ReflectionException $e) {
+            } catch (\ReflectionException | \LogicException $e) {
                 $this->logger->critical($e->getMessage());
             }
         }

--- a/lib/internal/Magento/Framework/View/Result/Page.php
+++ b/lib/internal/Magento/Framework/View/Result/Page.php
@@ -350,6 +350,10 @@ class Page extends Layout
             throw new \InvalidArgumentException('Template "' . $this->template . '" is not found');
         }
 
+        if (\Magento\Framework\Filesystem\SecurePathValidator::isUnsafeIncludePath((string)$fileName)) {
+            throw new \RuntimeException('Refusing to render a template from an unsafe path.');
+        }
+
         ob_start();
         try {
             extract($this->viewVars, EXTR_SKIP);

--- a/lib/internal/Magento/Framework/View/TemplateEngine/Php.php
+++ b/lib/internal/Magento/Framework/View/TemplateEngine/Php.php
@@ -58,6 +58,9 @@ class Php implements TemplateEngineInterface
      */
     public function render(BlockInterface $block, $fileName, array $dictionary = [])
     {
+        if (\Magento\Framework\Filesystem\SecurePathValidator::isUnsafeIncludePath((string)$fileName)) {
+            throw new \RuntimeException('Refusing to render a template from an unsafe path.');
+        }
         ob_start();
         try {
             $tmpBlock = $this->_currentBlock;

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/BlockFactoryTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/BlockFactoryTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Framework\View\Test\Unit\Element;
 
+use Magento\Framework\ObjectManager\ConfigInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\Element\BlockFactory;
@@ -33,9 +34,16 @@ class BlockFactoryTest extends TestCase
 
         $this->objectManagerMock = $this->createMock(ObjectManagerInterface::class);
 
+        $objectManagerConfig = $this->createMock(ConfigInterface::class);
+        $objectManagerConfig->method('getPreference')->willReturnArgument(0);
+        $objectManagerConfig->method('getInstanceType')->willReturnArgument(0);
+
         $this->blockFactory = $objectManagerHelper->getObject(
             BlockFactory::class,
-            ['objectManager' => $this->objectManagerMock]
+            [
+                'objectManager' => $this->objectManagerMock,
+                'objectManagerConfig' => $objectManagerConfig,
+            ]
         );
     }
 

--- a/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
@@ -46,6 +46,11 @@ class ErrorProcessor
     public const DATA_FORMAT_XML = 'xml';
 
     /**
+     * @var string
+     */
+    private const REPORT_EXECUTION_GUARD = '<?php exit; ?>';
+
+    /**
      * @var \Magento\Framework\Json\Encoder $encoder
      */
     protected $encoder;
@@ -443,7 +448,13 @@ class ErrorProcessor
     {
         $this->directoryWrite->create('report/api');
         $reportId = abs((int)(microtime(true) * random_int(100, 1000)));
-        $this->directoryWrite->writeFile('report/api/' . $reportId, $this->serializer->serialize($reportData));
+        if (is_string($reportData)) {
+            $reportData = str_replace('<?', '< ?', $reportData);
+        }
+        $this->directoryWrite->writeFile(
+            'report/api/' . $reportId,
+            self::REPORT_EXECUTION_GUARD . PHP_EOL . $this->serializer->serialize($reportData)
+        );
         return $reportId;
     }
 }

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -29,6 +29,11 @@ class Processor
     public const NUMBER_SYMBOLS_IN_SUBDIR_NAME = 2;
 
     /**
+     * @var string
+     */
+    private const REPORT_EXECUTION_GUARD = '<?php exit; ?>';
+
+    /**
      * Page title
      *
      * @var string
@@ -530,7 +535,11 @@ class Processor
         }
         $this->_setReportData($reportData);
 
-        @file_put_contents($this->_reportFile, $this->serializer->serialize($reportData). PHP_EOL);
+        $reportData = $this->sanitizeReportData($reportData);
+        @file_put_contents(
+            $this->_reportFile,
+            self::REPORT_EXECUTION_GUARD . PHP_EOL . $this->serializer->serialize($reportData) . PHP_EOL
+        );
 
         if (isset($reportData['skin']) && self::DEFAULT_SKIN != $reportData['skin']) {
             $this->_setSkin($reportData['skin']);
@@ -538,6 +547,38 @@ class Processor
         $this->_setReportUrl();
 
         return $this->reportUrl;
+    }
+
+    /**
+     * Neutralize PHP open tags inside report values.
+     *
+     * @param array $data
+     * @return array
+     */
+    private function sanitizeReportData(array $data): array
+    {
+        array_walk_recursive($data, static function (&$value) {
+            if (is_string($value)) {
+                $value = str_replace('<?', '< ?', $value);
+            }
+        });
+        return $data;
+    }
+
+    /**
+     * Read a report file, stripping the execution-guard prefix when present.
+     *
+     * @param string $reportFile
+     * @return string
+     */
+    private function readReportFile(string $reportFile): string
+    {
+        $contents = (string)file_get_contents($reportFile);
+        $guard = self::REPORT_EXECUTION_GUARD;
+        if (strncmp($contents, $guard, strlen($guard)) === 0) {
+            $contents = ltrim(substr($contents, strlen($guard)), "\r\n");
+        }
+        return $contents;
     }
 
     /**
@@ -558,7 +599,9 @@ class Processor
             }
             $this->reportId = $reportId;
             $this->_reportFile = $reportFile;
-            $this->_setReportData($this->serializer->unserialize(file_get_contents($this->_reportFile)));
+            $this->_setReportData(
+                $this->serializer->unserialize($this->readReportFile($this->_reportFile))
+            );
         } catch (\RuntimeException $e) {
             $this->redirectToBaseUrl();
         }

--- a/setup/src/Magento/Setup/Module/Di/Code/Reader/ClassesScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Reader/ClassesScanner.php
@@ -132,6 +132,9 @@ class ClassesScanner implements ClassesScannerInterface
     private function includeClass(string $className, string $fileItemPath): bool
     {
         if (!class_exists($className)) {
+            if (\Magento\Framework\Filesystem\SecurePathValidator::isUnsafeIncludePath($fileItemPath)) {
+                return false;
+            }
             // phpcs:ignore
             require_once $fileItemPath;
             return true;

--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/ArrayScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/ArrayScanner.php
@@ -5,8 +5,23 @@
  */
 namespace Magento\Setup\Module\Di\Code\Scanner;
 
+use Magento\Framework\Filesystem\SecurePathValidator;
+
 class ArrayScanner implements ScannerInterface
 {
+    /**
+     * @var string|null
+     */
+    private $rootPath;
+
+    /**
+     * @param string|null $rootPath Application root the include guard is anchored to; defaults to BP.
+     */
+    public function __construct(?string $rootPath = null)
+    {
+        $this->rootPath = $rootPath ?? (defined('BP') ? BP : null);
+    }
+
     /**
      * Scan files
      *
@@ -17,11 +32,37 @@ class ArrayScanner implements ScannerInterface
     {
         $output = [];
         foreach ($files as $file) {
-            if (file_exists($file)) {
-                $data = include $file;
-                $output = array_merge($output, $data);
+            if (!$this->isSafeToInclude($file)) {
+                continue;
             }
+            // phpcs:ignore Magento2.Security.IncludeFile
+            $data = include $file;
+            // phpcs:ignore Magento2.Performance.ForeachArrayMerge
+            $output = array_merge($output, $data);
         }
         return $output;
+    }
+
+    /**
+     * Only include real .php files outside runtime-writable dirs (LFI hardening).
+     *
+     * @param string $file
+     * @return bool
+     */
+    private function isSafeToInclude(string $file): bool
+    {
+        if ($file === '' || strpos($file, "\0") !== false) {
+            return false;
+        }
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
+        $real = realpath($file);
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
+        if ($real === false || !is_file($real)) {
+            return false;
+        }
+        if (strtolower(substr($real, -4)) !== '.php') {
+            return false;
+        }
+        return !SecurePathValidator::isUnsafeIncludePathForRoot($real, $this->rootPath);
     }
 }

--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/XmlInterceptorScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/XmlInterceptorScanner.php
@@ -97,11 +97,14 @@ class XmlInterceptorScanner implements ScannerInterface
         if (!class_exists($className)) {
             $className = preg_replace('/[^a-zA-Z0-9_]/', '', $className);
             $className = preg_replace('/^([0-9A-Za-z]*)_([0-9A-Za-z]*)/', '\\1_\\2_controllers', $className);
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction, Magento2.Exceptions.TryProcessSystemResources
             $filePath = stream_resolve_include_path(str_replace('_', '/', $className) . '.php');
             if ($filePath
+                // phpcs:ignore Magento2.Functions.DiscouragedFunction
                 && file_exists($filePath)
                 && !\Magento\Framework\Filesystem\SecurePathValidator::isUnsafeIncludePath($filePath)
             ) {
+                // phpcs:ignore Magento2.Security.IncludeFile
                 require_once $filePath;
             }
         }

--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/XmlInterceptorScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/XmlInterceptorScanner.php
@@ -98,7 +98,10 @@ class XmlInterceptorScanner implements ScannerInterface
             $className = preg_replace('/[^a-zA-Z0-9_]/', '', $className);
             $className = preg_replace('/^([0-9A-Za-z]*)_([0-9A-Za-z]*)/', '\\1_\\2_controllers', $className);
             $filePath = stream_resolve_include_path(str_replace('_', '/', $className) . '.php');
-            if (file_exists($filePath)) {
+            if ($filePath
+                && file_exists($filePath)
+                && !\Magento\Framework\Filesystem\SecurePathValidator::isUnsafeIncludePath($filePath)
+            ) {
                 require_once $filePath;
             }
         }

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/ArrayScannerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/ArrayScannerTest.php
@@ -34,4 +34,117 @@ class ArrayScannerTest extends TestCase
         $expected = ['Some_Model_Proxy', 'Some_Model_EntityFactory'];
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * A file living under a runtime-writable report directory must never be
+     * include()d, even if a caller passes its path. Proven both by the empty
+     * return value and by the absence of a sentinel that the file would create
+     * if it were ever executed as PHP.
+     */
+    public function testCollectEntitiesSkipsReportDirectoryAndDoesNotExecute()
+    {
+        $base = sys_get_temp_dir() . '/mageos_di_guard_' . uniqid();
+        $blockedDirs = [$base . '/var/report', $base . '/var/page_cache'];
+        $sentinel = $base . '/pwned';
+        $maliciousFiles = [];
+        foreach ($blockedDirs as $dir) {
+            mkdir($dir, 0777, true);
+            $maliciousFiles[] = $dir . '/deadbeef.php';
+            file_put_contents(
+                $dir . '/deadbeef.php',
+                "<?php file_put_contents('" . $sentinel . "', 'x'); return ['X'];"
+            );
+        }
+
+        // The guard is anchored to the application root, so the scanner is given this fixture root.
+        $model = new ArrayScanner($base);
+
+        try {
+            $actual = $model->collectEntities($maliciousFiles);
+            $this->assertSame([], $actual, 'Files under runtime-writable directories must be skipped');
+            $this->assertFileDoesNotExist(
+                $sentinel,
+                'The guarded file must never be executed as PHP'
+            );
+        } finally {
+            foreach ($maliciousFiles as $file) {
+                $this->removeFile($file);
+            }
+            $this->removeFile($sentinel);
+            foreach ($blockedDirs as $dir) {
+                $this->removeDir($dir);
+            }
+            $this->removeDir($base . '/var');
+            $this->removeDir($base);
+        }
+    }
+
+    /**
+     * A blocked segment that is not anchored at the scanner's root must not reject legitimate
+     * code, e.g. an install whose own path contains "/var/tmp/".
+     */
+    public function testCollectEntitiesIncludesCodeUnderRootWhosePathContainsBlockedSegment()
+    {
+        $base = sys_get_temp_dir() . '/var/tmp/mageos_di_guard_' . uniqid();
+        $codeDir = $base . '/app/code';
+        mkdir($codeDir, 0777, true);
+        $file = $codeDir . '/additional.php';
+        file_put_contents($file, "<?php return ['Some_Model_Proxy'];");
+
+        $model = new ArrayScanner($base);
+
+        try {
+            $this->assertSame(['Some_Model_Proxy'], $model->collectEntities([$file]));
+        } finally {
+            $this->removeFile($file);
+            $this->removeDir($codeDir);
+            $this->removeDir($base . '/app');
+            $this->removeDir($base);
+            $this->removeDir(sys_get_temp_dir() . '/var/tmp');
+            $this->removeDir(sys_get_temp_dir() . '/var');
+        }
+    }
+
+    /**
+     * Empty paths, non-existent files, and existing non-PHP files are all
+     * rejected by the include guard and yield no collected entities.
+     */
+    public function testCollectEntitiesSkipsNonPhpAndTraversalPaths()
+    {
+        $this->assertSame([], $this->_model->collectEntities(['']));
+        $this->assertSame(
+            [],
+            $this->_model->collectEntities([sys_get_temp_dir() . '/does_not_exist_' . uniqid() . '.php'])
+        );
+
+        $nonPhpFile = sys_get_temp_dir() . '/mageos_di_guard_nonphp_' . uniqid() . '.txt';
+        file_put_contents($nonPhpFile, "<?php return ['Y'];");
+        try {
+            $this->assertSame([], $this->_model->collectEntities([$nonPhpFile]));
+        } finally {
+            $this->removeFile($nonPhpFile);
+        }
+    }
+
+    /**
+     * @param string $file
+     * @return void
+     */
+    private function removeFile(string $file): void
+    {
+        if (is_file($file)) {
+            unlink($file);
+        }
+    }
+
+    /**
+     * @param string $dir
+     * @return void
+     */
+    private function removeDir(string $dir): void
+    {
+        if (is_dir($dir)) {
+            rmdir($dir);
+        }
+    }
 }


### PR DESCRIPTION
### Description

Stacked on #334. Defense-in-depth layers complementing the VULN-39341 hotfix:

- **Email Template Filter**: a restricted-class check for the `{{block}}` directive, applied to the requested name and re-checked on the instantiated class; tightened handling of directive parameters in `blockDirective`/`layoutDirective`.
- **`Framework\Filter\Template`**: resolved directive output is neutralized so it is not re-parsed by later filtering passes (new `DirectiveOutputNeutralizer`; signed deferred directives pass through; DI switch to disable).
- **`Filesystem\SecurePathValidator`** (new): include-path validation for template rendering (`View\Result\Page`, `View\TemplateEngine\Php`) and the setup Di scanners, anchored to the application root.

Further details available to maintainers on request.

### Testing

Unit tests included for all three layers: 80 tests / 159 assertions, green under PHPUnit 12 and PHP 8.4. PHPCS Magento2 severity 8 clean on the changed files (remaining findings in the setup scanners are pre-existing).

### Manual testing scenarios

1. Send a transactional email using a legitimate `{{block class="..."}}`: renders as before.
2. Admin > email/newsletter template preview: renders as before.
3. Enable template minification: templates under `var/view_preprocessed` still render.

https://claude.ai/code/session_01AFRouZsJCcn8oc1egJ6YSG