### PR TITLE
Fix: on-the-fly image regeneration silently does nothing for images with no media gallery row

### DIFF
--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -172,11 +172,6 @@ class ImageResize
         $viewImages = $this->getViewImages($this->getThemesInUse());
         if ($skipHiddenImages) {
             $websiteIds = $this->productImage->getRelatedWebsiteIds($originalImageName);
-            // An image file with no catalog_product_entity_media_gallery row resolves to no
-            // website at all. Filtering on an empty set discards every view configuration, so
-            // the on-the-fly regeneration performed by MediaStorage\App\Media generates nothing
-            // and the placeholder is served permanently, with no error reported anywhere.
-            // Narrow the set down only when the lookup actually returned something.
             if ($websiteIds) {
                 $viewImages = array_filter(
                     $viewImages,

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -172,11 +172,18 @@ class ImageResize
         $viewImages = $this->getViewImages($this->getThemesInUse());
         if ($skipHiddenImages) {
             $websiteIds = $this->productImage->getRelatedWebsiteIds($originalImageName);
-            $viewImages = array_filter(
-                $viewImages,
-                fn (string $index) => array_intersect($websiteIds, $this->paramsWebsitesMap[$index]),
-                ARRAY_FILTER_USE_KEY
-            );
+            // An image file with no catalog_product_entity_media_gallery row resolves to no
+            // website at all. Filtering on an empty set discards every view configuration, so
+            // the on-the-fly regeneration performed by MediaStorage\App\Media generates nothing
+            // and the placeholder is served permanently, with no error reported anywhere.
+            // Narrow the set down only when the lookup actually returned something.
+            if ($websiteIds) {
+                $viewImages = array_filter(
+                    $viewImages,
+                    fn (string $index) => array_intersect($websiteIds, $this->paramsWebsitesMap[$index] ?? []),
+                    ARRAY_FILTER_USE_KEY
+                );
+            }
         }
         foreach ($viewImages as $viewImage) {
             $this->resize($viewImage, $originalImagePath, $originalImageName);


### PR DESCRIPTION
### Description (*)

`MediaStorage\App\Media::createLocalCopy()` calls the resize service with `$skipHiddenImages = true`:

```php
$this->imageResize->resizeFromImageName($this->getOriginalImage($this->relativeFileName), true);
```

`ImageResize::resizeFromImageName()` then narrows the view configurations down to the websites the image belongs to:

```php
$viewImages = $this->getViewImages($this->getThemesInUse());
if ($skipHiddenImages) {
    $websiteIds = $this->productImage->getRelatedWebsiteIds($originalImageName);
    $viewImages = array_filter(
        $viewImages,
        fn (string $index) => array_intersect($websiteIds, $this->paramsWebsitesMap[$index]),
        ARRAY_FILTER_USE_KEY
    );
}
```

`getRelatedWebsiteIds()` looks the file up in `catalog_product_entity_media_gallery`. When the file has no row there — which happens whenever a role attribute such as `small_image` points at a file that is not, or is no longer, a gallery entry — it returns an empty array. `array_intersect()` against an empty array matches nothing, `$viewImages` becomes empty, the resize loop iterates over nothing, and `Media::launch()` falls through to `setPlaceholderImage()`.

The result is a permanent placeholder. No file is written, no exception escapes (the `catch` in `launch()` swallows everything), and nothing is logged, so every later request repeats the same no-op. The confusing part is the asymmetry it creates: `bin/magento catalog:images:resize` repairs such an image, because it does not pass the flag, while the storefront never does.

This PR applies the filter only when the lookup actually returned something, which keeps the optimisation for the case it was written for and restores the fallback everywhere else:

```php
if ($websiteIds) {
    $viewImages = array_filter(
        $viewImages,
        fn (string $index) => array_intersect($websiteIds, $this->paramsWebsitesMap[$index] ?? []),
        ARRAY_FILTER_USE_KEY
    );
}
```

The `?? []` also covers a missing `paramsWebsitesMap` key, which raises a `TypeError` under PHP 8 through the same code path.

An alternative you may prefer: stop forcing `true` in `Media::createLocalCopy()`. On-the-fly regeneration is a user-facing fallback, and `--skip-hidden-images` reads as an explicit CLI opt-in rather than something the storefront should apply on its own. I went with the guard because it also protects any other caller.

Note on scope: `resizeFromThemes()` carries the same `array_intersect` pattern, but there `$skipHiddenImages` is an explicit CLI flag and the image list comes from the gallery table itself, so an empty website set is closer to the intended meaning. I left it untouched — happy to align both if you would rather have a single behaviour.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

None filed — reporting it directly as a pull request. Happy to open an issue if you prefer to track it that way.

### Manual testing scenarios (*)

1. On a store with `web/url/catalog_media_url_format` set to `hash` (the default), pick a product whose `small_image` value points at a file that exists under `pub/media/catalog/product/` but has **no** row in `catalog_product_entity_media_gallery`. Such rows are common after an import that rewrites galleries while leaving the role attributes in place; you can also reproduce it by deleting the gallery row for a product image while keeping the `small_image` attribute value.
2. Make sure the resized file is absent, for example `rm pub/media/catalog/product/cache/<hash>/<x>/<y>/<file>.jpg`.
3. Request that cache URL over HTTP.

**Expected result:** `pub/get.php` regenerates the resized image and serves it.

**Actual result before this change:** the placeholder is served — a PNG under a `.jpg` URL, with no `Last-Modified` and no `Cache-Control` — in roughly 140 ms. No file appears under `cache/`, and nothing is written to `var/log/` or `var/report/`.

Measured on a 2.4.7 / Mage-OS 3.4.0 production store:

```
/c/o/example_81.jpg   getRelatedWebsiteIds() = []            -> no gallery row
/c/o/example_34.jpg   getRelatedWebsiteIds() = [2,1,2,1,2,1] -> gallery row present

resizeFromImageName($file, true)  :  86 ms, no file written
resizeFromImageName($file, false) : 305 ms, all 22 view configurations written
```

On that store, 10,108 of 47,751 distinct `small_image` values (21.2%) are in this state, so this is not a corner case once a catalog has been through an import that rewrites galleries.

4. Apply this change, request the same URL again: the resized image is generated and served, and the file appears under `cache/`.

### Questions or comments

Reproduced and verified on Mage-OS 3.4.0. The same code is present verbatim on `main` at the time of writing.
