### PR TITLE
Apply Adobe September 2026 security patch (249-2026-09-001)

### DIFF
--- a/app/code/Magento/Backup/Controller/Adminhtml/Index/Rollback.php
+++ b/app/code/Magento/Backup/Controller/Adminhtml/Index/Rollback.php
@@ -19,6 +19,11 @@ use Magento\Framework\Filesystem;
 class Rollback extends \Magento\Backup\Controller\Adminhtml\Index implements HttpPostActionInterface
 {
     /**
+     * @see _isAllowed()
+     */
+    public const ADMIN_RESOURCE = 'Magento_Backup::rollback';
+
+    /**
      * Rollback Action
      *
      * @return void|\Magento\Backend\App\Action
@@ -28,10 +33,6 @@ class Rollback extends \Magento\Backup\Controller\Adminhtml\Index implements Htt
      */
     public function execute()
     {
-        if (!$this->_objectManager->get(\Magento\Backup\Helper\Data::class)->isRollbackAllowed()) {
-            $this->_forward('denied');
-        }
-
         if (!$this->getRequest()->isAjax()) {
             return $this->_redirect('*/*/index');
         }

--- a/app/code/Magento/Customer/i18n/en_US.csv
+++ b/app/code/Magento/Customer/i18n/en_US.csv
@@ -551,3 +551,4 @@ T,T
 F,F
 VAT,VAT
 "Something went wrong while logging out customer.","Something went wrong while logging out customer."
+"Address not found.","Address not found."

--- a/app/code/Magento/CustomerGraphQl/Model/Context/AddUserInfoToContext.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Context/AddUserInfoToContext.php
@@ -12,9 +12,12 @@ use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Model\Config\Share;
 use Magento\Customer\Model\ResourceModel\CustomerRepository;
 use Magento\Customer\Model\Session;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\Request\Http as HttpRequest;
 use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
 use Magento\GraphQl\Model\Query\ContextParametersInterface;
 use Magento\GraphQl\Model\Query\UserContextParametersProcessorInterface;
+use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 /**
@@ -51,19 +54,27 @@ class AddUserInfoToContext implements UserContextParametersProcessorInterface, R
      * @var StoreManagerInterface
      */
     private $storeManager;
+
+    /**
+     * @var HttpRequest
+     */
+    private $request;
+
     /**
      * @param UserContextInterface $userContext
      * @param Session $session
      * @param CustomerRepository $customerRepository
      * @param Share $configShare
      * @param StoreManagerInterface $storeManager
+     * @param HttpRequest|null $request
      */
     public function __construct(
         UserContextInterface $userContext,
         Session $session,
         CustomerRepository $customerRepository,
         Share $configShare,
-        StoreManagerInterface $storeManager
+        StoreManagerInterface $storeManager,
+        ?HttpRequest $request = null
     ) {
         $this->userContext = $userContext;
         $this->userContextFromConstructor = $userContext;
@@ -71,6 +82,7 @@ class AddUserInfoToContext implements UserContextParametersProcessorInterface, R
         $this->customerRepository = $customerRepository;
         $this->configShare = $configShare;
         $this->storeManager = $storeManager;
+        $this->request = $request ?? ObjectManager::getInstance()->get(HttpRequest::class);
     }
 
     /**
@@ -109,6 +121,13 @@ class AddUserInfoToContext implements UserContextParametersProcessorInterface, R
         $isCustomer = $this->isCustomer($currentUserId, $currentUserType);
         $contextParameters->addExtensionAttribute('is_customer', $isCustomer);
 
+        if (!$isCustomer
+            && !empty($currentUserId)
+            && $currentUserType === UserContextInterface::USER_TYPE_CUSTOMER
+        ) {
+            $contextParameters->setUserId(0);
+        }
+
         if ($isCustomer) {
             $customer = $this->customerRepository->getById($currentUserId);
             $this->session->setCustomerData($customer);
@@ -142,8 +161,22 @@ class AddUserInfoToContext implements UserContextParametersProcessorInterface, R
 
         if ($result && $this->configShare->isWebsiteScope()) {
             $customer = $this->customerRepository->getById($customerId);
-            return (int)$customer->getWebsiteId() === (int)$this->storeManager->getStore()->getWebsiteId();
+            return (int)$customer->getWebsiteId() === (int)$this->getEffectiveStore()->getWebsiteId();
         }
         return $result;
+    }
+
+    /**
+     * Resolve the store to use for website-scope validation.
+     *
+     * @return StoreInterface
+     */
+    private function getEffectiveStore(): StoreInterface
+    {
+        $storeCode = trim((string) $this->request->getHeader('Store'));
+        if (!empty($storeCode)) {
+            return $this->storeManager->getStore($storeCode);
+        }
+        return $this->storeManager->getStore();
     }
 }

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
@@ -9,6 +9,7 @@ namespace Magento\ImportExport\Controller\Adminhtml\Export\File;
 
 use Magento\Backend\App\Action;
 use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\ValidatorException;
@@ -16,6 +17,7 @@ use Magento\ImportExport\Controller\Adminhtml\Export as ExportController;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\Filesystem\Directory\WriteFactory;
+use Magento\ImportExport\Model\Export\FileInfo;
 
 /**
  * Controller that delete file by name.
@@ -38,19 +40,27 @@ class Delete extends ExportController implements HttpPostActionInterface
     private $writeFactory;
 
     /**
+     * @var FileInfo
+     */
+    private $fileInfo;
+
+    /**
      * Delete constructor.
      *
      * @param Action\Context $context
      * @param Filesystem $filesystem
      * @param WriteFactory $writeFactory
+     * @param FileInfo|null $fileInfo
      */
     public function __construct(
         Action\Context $context,
         Filesystem $filesystem,
-        WriteFactory $writeFactory
+        WriteFactory $writeFactory,
+        ?FileInfo $fileInfo = null
     ) {
         $this->filesystem = $filesystem;
         $this->writeFactory = $writeFactory;
+        $this->fileInfo = $fileInfo ?? ObjectManager::getInstance()->get(FileInfo::class);
         parent::__construct($context);
     }
 
@@ -72,7 +82,15 @@ class Delete extends ExportController implements HttpPostActionInterface
             }
             $directoryWrite = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_IMPORT_EXPORT);
             try {
-                $directoryWrite->delete($directoryWrite->getAbsolutePath() . 'export/' . $fileName);
+                $fileName = $directoryWrite->getDriver()->getRealPathSafety(DIRECTORY_SEPARATOR . $fileName);
+                $fileExist = $directoryWrite->isFile('export' . $fileName);
+                if (!$fileExist || !$this->isAllowedExportFile($fileName)) {
+                    $this->messageManager->addErrorMessage(__(
+                        'Sorry, but the data is invalid or the file is not uploaded.'
+                    ));
+                    return $resultRedirect;
+                }
+                $directoryWrite->delete($directoryWrite->getAbsolutePath() . 'export' . $fileName);
                 $this->messageManager->addSuccessMessage(__('File %1 deleted', $fileName));
             } catch (ValidatorException $exception) {
                 $this->messageManager->addErrorMessage(
@@ -88,5 +106,16 @@ class Delete extends ExportController implements HttpPostActionInterface
         }
 
         return $resultRedirect;
+    }
+
+    /**
+     * Check whether requested file is a completed export file.
+     *
+     * @param string $fileName
+     * @return bool
+     */
+    private function isAllowedExportFile(string $fileName): bool
+    {
+        return $this->fileInfo->isExportFile($fileName);
     }
 }

--- a/app/code/Magento/InstantPurchase/Model/InstantPurchaseOptionLoadingFactory.php
+++ b/app/code/Magento/InstantPurchase/Model/InstantPurchaseOptionLoadingFactory.php
@@ -8,6 +8,7 @@ namespace Magento\InstantPurchase\Model;
 use Magento\Customer\Api\AddressRepositoryInterface;
 use Magento\Customer\Model\Address;
 use Magento\Customer\Model\AddressFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\Data\ShippingMethodInterfaceFactory;
 use Magento\Vault\Api\PaymentTokenManagementInterface;
 
@@ -85,6 +86,11 @@ class InstantPurchaseOptionLoadingFactory
         $paymentToken = $this->paymentTokenManagement->getByPublicHash($paymentTokenPublicHash, $customerId);
         $shippingAddress = $this->getAddress($shippingAddressId);
         $billingAddress = $this->getAddress($billingAddressId);
+        if ((int)$shippingAddress->getCustomerId() !== $customerId ||
+            (int)$billingAddress->getCustomerId() !== $customerId) {
+            throw new NoSuchEntityException(__('Address not found.'));
+        }
+
         $shippingMethod = $this->shippingMethodFactory->create()
             ->setCarrierCode($carrierCode)
             ->setMethodCode($shippingMethodCode);

--- a/app/code/Magento/Paypal/Controller/Express/AbstractExpress.php
+++ b/app/code/Magento/Paypal/Controller/Express/AbstractExpress.php
@@ -151,7 +151,7 @@ abstract class AbstractExpress extends AppAction implements
     protected function _initCheckout(?CartInterface $quoteObject = null)
     {
         $quote = $quoteObject ? $quoteObject : $this->_getQuote();
-        if ($quote->getId()) {
+        if ($quote->getId() && $this->isQuoteAllowedForUser($quote)) {
             $this->_getCheckoutSession()->setPayPalQuoteId($quote->getId());
         }
         if (!$quote->hasItems() || $quote->getHasError()) {
@@ -257,6 +257,22 @@ abstract class AbstractExpress extends AppAction implements
             }
         }
         return $this->_quote;
+    }
+
+    /**
+     * Checks if the quote is allowed for the current user.
+     *
+     * @param CartInterface $quote
+     * @return bool
+     */
+    private function isQuoteAllowedForUser(CartInterface $quote): bool
+    {
+        if ((int)$quote->getId() === (int)$this->_getCheckoutSession()->getQuoteId()) {
+            return true;
+        }
+
+        return $this->_customerSession->isLoggedIn()
+            && (int)$quote->getCustomerId() === (int)$this->_customerSession->getCustomerId();
     }
 
     /**

--- a/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
+++ b/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
@@ -5,6 +5,7 @@
 
  define([
     'jquery',
+    'underscore',
     'Magento_Ui/js/modal/confirm',
     'Magento_Ui/js/modal/alert',
     'mage/template',
@@ -14,7 +15,7 @@
     'prototype',
     'Magento_Catalog/catalog/product/composite/configure',
     'Magento_Ui/js/lib/view/utils/async'
-], function (jQuery, confirm, alert, template, shippingTemplate, paymentTemplate) {
+], function (jQuery, _, confirm, alert, template, shippingTemplate, paymentTemplate) {
 
     window.AdminOrder = new Class.create();
 
@@ -1496,6 +1497,7 @@
                 country: $(parameters.countryElementId).value,
                 vat: $(parameters.vatElementId).value
             };
+            var escapedVat = _.escape(params.vat);
 
             if (this.storeId !== false) {
                 params.store_id = this.storeId;
@@ -1516,7 +1518,7 @@
                             if (true === response.valid) {
                                 message = parameters.vatValidMessage;
                             } else if (true === response.success) {
-                                message = parameters.vatInvalidMessage.replace(/%s/, params.vat);
+                                message = parameters.vatInvalidMessage.replace(/%s/, escapedVat);
                             } else {
                                 message = parameters.vatValidationFailedMessage;
                             }
@@ -1531,7 +1533,7 @@
                                     groupActionRequired = 'change';
                                 }
                             } else if (response.success) {
-                                message = parameters.vatInvalidMessage.replace(/%s/, params.vat);
+                                message = parameters.vatInvalidMessage.replace(/%s/, escapedVat);
                                 groupActionRequired = 'inform';
                             } else {
                                 message = parameters.vatValidationFailedMessage;

--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -389,7 +389,7 @@ class Escaper
      */
     public function escapeXssInUrl($data)
     {
-        $data = html_entity_decode((string)$data);
+        $data = $this->decodeHtmlEntitiesToFixedPoint((string)$data);
         $this->getTranslateInline()->processResponseBody($data);
 
         return htmlspecialchars(
@@ -398,6 +398,26 @@ class Escaper
             'UTF-8',
             false
         );
+    }
+
+    /**
+     * Decode HTML entities repeatedly until stable, or return empty if still decoding at the cap.
+     *
+     * @param string $data
+     * @return string
+     */
+    private function decodeHtmlEntitiesToFixedPoint(string $data): string
+    {
+        $iterationCap = 10;
+        for ($iteration = 0; $iteration < $iterationCap; $iteration++) {
+            $decoded = html_entity_decode($data);
+            if ($decoded === $data) {
+                return $data;
+            }
+            $data = $decoded;
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
### Description

Ports Adobe's `249-2026-09-001-CE` (September 2026, 2.4.9) security patch to `main`. Seven independent fixes:

- **Backup Rollback controller**: replaces the in-`execute()` `isRollbackAllowed()` helper check (which called `_forward('denied')` without returning, so execution continued) with `ADMIN_RESOURCE = 'Magento_Backup::rollback'` — the same ACL resource, now enforced by the framework before dispatch.
- **CustomerGraphQl AddUserInfoToContext**: resets the context user id to 0 when a customer-type token fails the `isCustomer` check, and validates website scope against the store from the `Store` header rather than the default store.
- **ImportExport export-file Delete controller**: normalizes the requested path with `getRealPathSafety()` and only deletes files that exist and pass `FileInfo::isExportFile()` (path traversal / arbitrary file deletion).
- **InstantPurchase option loading**: verifies the shipping/billing address ids belong to the current customer (IDOR).
- **PayPal Express `_initCheckout()`**: only stores the quote id in the checkout session when the quote is the session quote or owned by the logged-in customer.
- **Admin order create `scripts.js`**: escapes the VAT number before interpolating it into validation messages (XSS).
- **Framework `Escaper::escapeXssInUrl()`**: decodes HTML entities to a fixed point (cap 10 iterations, empty string on overflow) instead of a single `html_entity_decode()` pass, closing double-encoding bypasses.

All hunks are verbatim from Adobe's patch, with vendor paths mapped to repo paths; every hunk applied cleanly against `main`. The `Customer/i18n/en_US.csv` line adds the "Address not found." phrase used by the InstantPurchase fix. Both dependencies the patch assumes (`ImportExport\Model\Export\FileInfo::isExportFile()`, the `Magento_Backup::rollback` ACL resource) already exist on `main`.

Evaluated against #334 / #335 (VULN-39341 StyleSmuggler): zero file overlap and no behavioral interaction, so this PR is unstacked on `main`.

### Testing

- `php -l` clean on all changed PHP files (PHP 8.4).
- `Framework\Test\Unit\EscaperTest`: 98 tests / 409 assertions green — the only pre-existing unit coverage of changed code. Adobe ships no test updates.
- PHPCS Magento2 severity 8 clean on all changed files.

### Manual testing scenarios

1. Admin > System > Backups > rollback: works for an admin with `Magento_Backup::rollback`, denied without it.
2. Admin > System > Export > delete a completed export file: succeeds; a traversal-style filename is rejected with an error message.
3. PayPal Express checkout as guest and logged-in customer: unchanged.

https://claude.ai/code/session_01AFRouZsJCcn8oc1egJ6YSG